### PR TITLE
Return at least paymentMethodId when confirming setupIntent on iOS

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -394,7 +394,9 @@ public class StripePlugin: CAPPlugin {
                 call.error("user cancelled the transaction")
 
             case .succeeded:
-                call.success()
+                call.success([
+                    "paymentMethodId": pip.paymentMethodID!
+                ])
             }
         }
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -395,7 +395,7 @@ public class StripePlugin: CAPPlugin {
 
             case .succeeded:
                 call.success([
-                    "paymentMethodId": pip.paymentMethodID!
+                    "paymentMethodId": si?.paymentMethodID! ?? nil
                 ])
             }
         }


### PR DESCRIPTION
This only affects iOS.

Currently, even though the `confirmSetupIntent` is successful, the plugin just returns an empty JavaScript object `{}` upon success. It is important to get the `paymentMethodId` from a successful confirmation so that the `paymentMethodId` is registered to the Stripe User.

This Pull Request just returns the `paymentMethodId` when `confirmSetupIntent` succeeds. I don't know where to get the other data that the interface `ConfirmSetupIntentResponse` has, however, this should help make `confirmSetupIntent` at least useful in iOS.