### PR TITLE
Send plugin AppInfo

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -24,6 +24,8 @@ public class StripePlugin extends Plugin {
 
     private MetaData metaData;
 
+    private static final String APP_INFO_NAME = "@capacitor-community/stripe";
+
     private final PaymentSheetExecutor paymentSheetExecutor = new PaymentSheetExecutor(
         this::getContext,
         this::getActivity,
@@ -51,6 +53,7 @@ public class StripePlugin extends Plugin {
         if (metaData.enableGooglePay) {
             this.publishableKey = metaData.publishableKey;
             PaymentConfiguration.init(getContext(), metaData.publishableKey);
+            Stripe.setAppInfo(AppInfo.create(APP_INFO_NAME));
 
             this.googlePayExecutor.googlePayLauncher =
                 new GooglePayLauncher(
@@ -95,6 +98,7 @@ public class StripePlugin extends Plugin {
                     return;
                 }
                 PaymentConfiguration.init(getContext(), publishableKey);
+                Stripe.setAppInfo(AppInfo.create(APP_INFO_NAME));
             } else {
                 Logger.info("PaymentConfiguration.init was run at load");
             }

--- a/ios/Plugin/StripePlugin.swift
+++ b/ios/Plugin/StripePlugin.swift
@@ -28,6 +28,8 @@ public class StripePlugin: CAPPlugin {
 
         StripeAPI.defaultPublishableKey = publishableKey
 
+        STPAPIClient.shared.appInfo = STPAppInfo(name: "@capacitor-community/stripe", partnerId: nil, version: nil, url: nil)
+        
         call.resolve()
     }
 


### PR DESCRIPTION
Hello! I was recently taking inventory of plugins wrapping our iOS and Android SDKs, and I noticed that your plugin isn't sending a user-agent [via the `AppInfo` field](https://stripe.com/docs/building-plugins). Would you mind if I changed this? It would help us provide better support for our users when they call in with integration questions.

I'm not very familiar with Capacitor, so please let me know if this isn't the right place to add this code. Thanks!