### PR TITLE
chore: demo app import path should be relative

### DIFF
--- a/demo/angular/src/app/tab1/tab1.page.ts
+++ b/demo/angular/src/app/tab1/tab1.page.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {ApplePayEventsEnum, PaymentFlowEventsEnum, PaymentSheetEventsEnum, Stripe} from '@capacitor-community/stripe';
+import {ApplePayEventsEnum, PaymentFlowEventsEnum, PaymentSheetEventsEnum, Stripe} from '../../../../../dist/esm';
 import {environment} from '../../environments/environment';
 import {HttpClient} from '@angular/common/http';
 import {first} from 'rxjs/operators';


### PR DESCRIPTION
The demo application does not install the `@capacitor-community/stripe` library.
So we need to use the internal module.