### PR TITLE
feat: can create PaymentSheet and PaymentFlow without customer id

### DIFF
--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -29,7 +29,7 @@ export interface BasePaymentOption {
   /**
    * Any documentation call 'customer'
    */
-  customerId: string;
+  customerId?: string;
 
   /**
    * If you set payment method ApplePay, this set true


### PR DESCRIPTION
Ref: #116
The `customerId` prop is not required property in Stripe. So we can change this from required to optional.

# Try to run (without customer id)
We can test this by the following steps.

## Payment Sheet
- Run `npm run build`
- Go to demo app (`demo/angular`)
- Run `npm install`
- Delete these line -> https://github.com/capacitor-community/stripe/blob/feat/no-customer-id/demo/angular/src/app/tab2/tab2.page.ts#L89-L90
- Run `npm start`
- Go to http://localhost:4200/tabs/tab2
- Click "Expect Happy Path"


## Payment Flow
- Run `npm run build`
- Go to demo app (`demo/angular`)
- Run `npm install`
- Delete these line -> https://github.com/capacitor-community/stripe/blob/feat/no-customer-id/demo/angular/src/app/tab3/tab3.page.ts#L112-L113
- Run `npm start`
- Go to http://localhost:4200/tabs/tab3
- Click "Expect Happy Path"
