### PR TITLE
remove only one key initialization condition

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -93,7 +93,7 @@ public class StripePlugin extends Plugin {
     @PluginMethod
     public void initialize(final PluginCall call) {
         try {
-            if (publishableKey == null) {
+            // if (publishableKey == null) {
                 publishableKey = call.getString("publishableKey");
 
                 if (publishableKey == null || publishableKey.equals("")) {
@@ -105,9 +105,9 @@ public class StripePlugin extends Plugin {
 
                 PaymentConfiguration.init(getContext(), publishableKey, stripeAccountId);
                 Stripe.setAppInfo(AppInfo.create(APP_INFO_NAME));
-            } else {
-                Logger.info("PaymentConfiguration.init was run at load");
-            }
+            // } else {
+            //     Logger.info("PaymentConfiguration.init was run at load");
+            // }
             call.resolve();
         } catch (Exception e) {
             call.reject("unable to set publishable key: " + e.getLocalizedMessage(), e);


### PR DESCRIPTION
We have a need to work with different stripe accounts in one application. With each payment, we change and initialize different public keys from different companies. But initialization worked painlessly only on ios, on android we found a small flaw in the plugin code. 
If you remove the check for an empty publishableKey, then everything works as it should) 

If possible, please add this to the update or if you have any ideas on how to improve and secure the code, I will be glad to any suggestions