### PR TITLE
Add Stripe Identity

### DIFF
--- a/CapacitorCommunityStripe.podspec
+++ b/CapacitorCommunityStripe.podspec
@@ -15,5 +15,6 @@ Pod::Spec.new do |s|
   s.dependency 'Capacitor'
   s.dependency 'StripePaymentSheet', '23.3.2'
   s.dependency 'StripeApplePay', '23.3.2'
+  s.dependency 'StripeIdentity', '23.3.2'
   s.swift_version = '5.1'
 end

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Learn at [the official @capacitor-community/stripe documentation](https://stripe
 * [`addListener(GooglePayEventsEnum.Completed, ...)`](#addlistenergooglepayeventsenumcompleted)
 * [`addListener(GooglePayEventsEnum.Canceled, ...)`](#addlistenergooglepayeventsenumcanceled)
 * [`addListener(GooglePayEventsEnum.Failed, ...)`](#addlistenergooglepayeventsenumfailed)
+* [`createIdentityVerificationSheet(...)`](#createidentityverificationsheet)
+* [`presentIdentityVerificationSheet()`](#presentidentityverificationsheet)
+* [`addListener(IdentityVerificationSheetEventsEnum.Loaded, ...)`](#addlisteneridentityverificationsheeteventsenumloaded)
+* [`addListener(IdentityVerificationSheetEventsEnum.FailedToLoad, ...)`](#addlisteneridentityverificationsheeteventsenumfailedtoload)
+* [`addListener(IdentityVerificationSheetEventsEnum.Completed, ...)`](#addlisteneridentityverificationsheeteventsenumcompleted)
+* [`addListener(IdentityVerificationSheetEventsEnum.Canceled, ...)`](#addlisteneridentityverificationsheeteventsenumcanceled)
+* [`addListener(IdentityVerificationSheetEventsEnum.Failed, ...)`](#addlisteneridentityverificationsheeteventsenumfailed)
 * [`createPaymentFlow(...)`](#createpaymentflow)
 * [`presentPaymentFlow()`](#presentpaymentflow)
 * [`confirmPaymentFlow()`](#confirmpaymentflow)
@@ -354,6 +361,110 @@ addListener(eventName: GooglePayEventsEnum.Failed, listenerFunc: () => void) => 
 | ------------------ | -------------------------------------------------------------------------- |
 | **`eventName`**    | <code><a href="#googlepayeventsenum">GooglePayEventsEnum.Failed</a></code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>                                                 |
+
+**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### createIdentityVerificationSheet(...)
+
+```typescript
+createIdentityVerificationSheet(options: CreateIdentityVerificationSheetOption) => Promise<void>
+```
+
+| Param         | Type                                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#createidentityverificationsheetoption">CreateIdentityVerificationSheetOption</a></code> |
+
+--------------------
+
+
+### presentIdentityVerificationSheet()
+
+```typescript
+presentIdentityVerificationSheet() => Promise<{ identityVerificationResult: IdentityVerificationSheetResultInterface; }>
+```
+
+**Returns:** <code>Promise&lt;{ identityVerificationResult: <a href="#identityverificationsheetresultinterface">IdentityVerificationSheetResultInterface</a>; }&gt;</code>
+
+--------------------
+
+
+### addListener(IdentityVerificationSheetEventsEnum.Loaded, ...)
+
+```typescript
+addListener(eventName: IdentityVerificationSheetEventsEnum.Loaded, listenerFunc: () => void) => PluginListenerHandle
+```
+
+| Param              | Type                                                                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Loaded</a></code> |
+| **`listenerFunc`** | <code>() =&gt; void</code>                                                                                 |
+
+**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### addListener(IdentityVerificationSheetEventsEnum.FailedToLoad, ...)
+
+```typescript
+addListener(eventName: IdentityVerificationSheetEventsEnum.FailedToLoad, listenerFunc: (error: string) => void) => PluginListenerHandle
+```
+
+| Param              | Type                                                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.FailedToLoad</a></code> |
+| **`listenerFunc`** | <code>(error: string) =&gt; void</code>                                                                          |
+
+**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### addListener(IdentityVerificationSheetEventsEnum.Completed, ...)
+
+```typescript
+addListener(eventName: IdentityVerificationSheetEventsEnum.Completed, listenerFunc: () => void) => PluginListenerHandle
+```
+
+| Param              | Type                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Completed</a></code> |
+| **`listenerFunc`** | <code>() =&gt; void</code>                                                                                    |
+
+**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### addListener(IdentityVerificationSheetEventsEnum.Canceled, ...)
+
+```typescript
+addListener(eventName: IdentityVerificationSheetEventsEnum.Canceled, listenerFunc: () => void) => PluginListenerHandle
+```
+
+| Param              | Type                                                                                                         |
+| ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| **`eventName`**    | <code><a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Canceled</a></code> |
+| **`listenerFunc`** | <code>() =&gt; void</code>                                                                                   |
+
+**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### addListener(IdentityVerificationSheetEventsEnum.Failed, ...)
+
+```typescript
+addListener(eventName: IdentityVerificationSheetEventsEnum.Failed, listenerFunc: (error: string) => void) => PluginListenerHandle
+```
+
+| Param              | Type                                                                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Failed</a></code> |
+| **`listenerFunc`** | <code>(error: string) =&gt; void</code>                                                                    |
 
 **Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
@@ -701,6 +812,14 @@ iOS Only
 | **`currency`**                  | <code>string</code>                               | Web only need @stripe-elements/stripe-elements &gt; 1.1.0 |
 
 
+#### CreateIdentityVerificationSheetOption
+
+| Prop                     | Type                |
+| ------------------------ | ------------------- |
+| **`verificationId`**     | <code>string</code> |
+| **`ephemeralKeySecret`** | <code>string</code> |
+
+
 #### CreatePaymentFlowOption
 
 | Prop                             | Type                                       | Description                                                                                      | Default                 |
@@ -784,6 +903,11 @@ iOS Only
 <code><a href="#googlepayeventsenum">GooglePayEventsEnum.Completed</a> | <a href="#googlepayeventsenum">GooglePayEventsEnum.Canceled</a> | <a href="#googlepayeventsenum">GooglePayEventsEnum.Failed</a></code>
 
 
+#### IdentityVerificationSheetResultInterface
+
+<code><a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Completed</a> | <a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Canceled</a> | <a href="#identityverificationsheeteventsenum">IdentityVerificationSheetEventsEnum.Failed</a></code>
+
+
 #### PaymentFlowResultInterface
 
 <code><a href="#paymentfloweventsenum">PaymentFlowEventsEnum.Completed</a> | <a href="#paymentfloweventsenum">PaymentFlowEventsEnum.Canceled</a> | <a href="#paymentfloweventsenum">PaymentFlowEventsEnum.Failed</a></code>
@@ -819,6 +943,17 @@ iOS Only
 | **`Completed`**    | <code>"googlePayCompleted"</code>    |
 | **`Canceled`**     | <code>"googlePayCanceled"</code>     |
 | **`Failed`**       | <code>"googlePayFailed"</code>       |
+
+
+#### IdentityVerificationSheetEventsEnum
+
+| Members            | Value                                                |
+| ------------------ | ---------------------------------------------------- |
+| **`Loaded`**       | <code>"identityVerificationSheetLoaded"</code>       |
+| **`FailedToLoad`** | <code>"identityVerificationSheetFailedToLoad"</code> |
+| **`Completed`**    | <code>"identityVerificationSheetCompleted"</code>    |
+| **`Canceled`**     | <code>"identityVerificationSheetCanceled"</code>     |
+| **`Failed`**       | <code>"identityVerificationSheetFailed"</code>       |
 
 
 #### PaymentFlowEventsEnum

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,8 +58,8 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation 'com.stripe:stripe-android:20.11.0'
-    implementation 'com.stripe:stripecardscan:20.11.0'
+    implementation 'com.stripe:stripe-android:20.19.3'
+    implementation 'com.stripe:identity:20.19.3'
     implementation 'com.google.android.gms:play-services-wallet:19.1.0'
     implementation 'com.google.code.gson:gson:2.8.9'
 

--- a/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -1,8 +1,8 @@
 package com.getcapacitor.community.stripe;
 
+import android.content.ContentResolver;
+import android.content.res.Resources;
 import android.net.Uri;
-import android.provider.ContactsContract;
-
 import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -103,11 +103,19 @@ public class StripePlugin extends Plugin {
                 }
             );
 
+        Resources resources = getActivity().getApplicationContext().getResources();
+        int resourceId = resources.getIdentifier("ic_launcher", "mipmap", getActivity().getPackageName());
+        Uri icon = new Uri.Builder()
+            .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
+            .authority(resources.getResourcePackageName(resourceId))
+            .appendPath(resources.getResourceTypeName(resourceId))
+            .appendPath(resources.getResourceEntryName(resourceId))
+            .build();
+
         this.identityVerificationSheetExecutor.verificationSheet =
         IdentityVerificationSheet.Companion.create(
             getActivity(),
-            // TODO: update this to a resource
-            new IdentityVerificationSheet.Configuration(Uri.parse("https://raw.githubusercontent.com/ionic-team/capacitor/2d9f058c8d48c8468225ab7af1cc2a7073a54ab5/android-template/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png")),
+            new IdentityVerificationSheet.Configuration(icon),
             verificationFlowResult -> {
                 // handle verificationResult
                 if (verificationFlowResult instanceof IdentityVerificationSheet.VerificationFlowResult.Completed) {

--- a/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -102,31 +102,26 @@ public class StripePlugin extends Plugin {
                     this.paymentFlowExecutor.onPaymentFlowResult(bridge, paymentFlowCallbackId, result);
                 }
             );
-                
 
         this.identityVerificationSheetExecutor.verificationSheet =
         IdentityVerificationSheet.Companion.create(
             getActivity(),
-            // pass your brand logo by creating it from local resource or
-            // Uri.parse("https://path/to/a/logo.jpg")
-            new IdentityVerificationSheet.Configuration(Uri.parse("https://source.unsplash.com/random/300×300")),
+            // TODO: update this to a resource
+            new IdentityVerificationSheet.Configuration(Uri.parse("https://raw.githubusercontent.com/ionic-team/capacitor/2d9f058c8d48c8468225ab7af1cc2a7073a54ab5/android-template/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png")),
             verificationFlowResult -> {
                 // handle verificationResult
                 if (verificationFlowResult instanceof IdentityVerificationSheet.VerificationFlowResult.Completed) {
                     // The user has completed uploading their documents.
                     // Let them know that the verification is processing.
-                
-                    Logger.info("Verification Flow Completed!");
+                    this.identityVerificationSheetExecutor.onVerificationCompleted(bridge, identityVerificationCallbackId);
                 } else if (verificationFlowResult instanceof IdentityVerificationSheet.VerificationFlowResult.Canceled) {
                     // The user did not complete uploading their documents.
                     // You should allow them to try again.
-
-                    Logger.info("Verification Flow Canceled!");
+                    this.identityVerificationSheetExecutor.onVerificationCancelled(bridge, identityVerificationCallbackId);
                 } else if (verificationFlowResult instanceof IdentityVerificationSheet.VerificationFlowResult.Failed) {
                     // If the flow fails, you should display the localized error
                     // message to your user using throwable.getLocalizedMessage()
-
-                    Logger.info("Verification Flow Failed!");
+                    this.identityVerificationSheetExecutor.onVerificationFailed(bridge, identityVerificationCallbackId);
                 }
             }
         );

--- a/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetEvent.kt
+++ b/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetEvent.kt
@@ -1,0 +1,9 @@
+package com.getcapacitor.community.stripe.identityverification;
+
+enum class IdentityVerificationSheetEvent(val webEventName: String) {
+    Loaded("identityVerificationSheetLoaded"),
+    FailedToLoad("identityVerificationSheetFailedToLoad"),
+    Completed("identityVerificationSheetCompleted"),
+    Canceled("identityVerificationSheetCanceled"),
+    Failed("identityVerificationSheetFailed"),
+}

--- a/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetExecutor.java
@@ -35,7 +35,7 @@ public class IdentityVerificationSheetExecutor extends Executor {
         verificationId = call.getString("verificationId", null);
         ephemeralKeySecret = call.getString("ephemeralKeySecret", null);
 
-        if (verificationId == null && ephemeralKeySecret == null) {
+        if (verificationId == null || ephemeralKeySecret == null) {
             String errorText = "Invalid Params. This method require verificationId or ephemeralKeySecret.";
             notifyListenersFunction.accept(IdentityVerificationSheetEvent.FailedToLoad.getWebEventName(), new JSObject().put("error", errorText));
             call.reject(errorText);

--- a/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetExecutor.java
@@ -1,0 +1,57 @@
+package com.getcapacitor.community.stripe.identityverification;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.core.util.Supplier;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.community.stripe.models.Executor;
+import com.google.android.gms.common.util.BiConsumer;
+import com.stripe.android.identity.IdentityVerificationSheet;
+
+public class IdentityVerificationSheetExecutor extends Executor {
+
+    public IdentityVerificationSheet verificationSheet;
+    private final JSObject emptyObject = new JSObject();
+
+    private String verificationId;
+    private String ephemeralKeySecret;
+
+    public IdentityVerificationSheetExecutor(
+        Supplier<Context> contextSupplier,
+        Supplier<Activity> activitySupplier,
+        BiConsumer<String, JSObject> notifyListenersFunction,
+        String pluginLogTag
+    ) {
+        super(contextSupplier, activitySupplier, notifyListenersFunction, pluginLogTag, "VerificationSheetExecutor");
+        this.contextSupplier = contextSupplier;
+    }
+
+    public void createIdentityVerificationSheet(final PluginCall call) {
+        verificationId = call.getString("verificationId", null);
+        ephemeralKeySecret = call.getString("ephemeralKeySecret", null);
+
+        String customerEphemeralKeySecret = call.getString("customerEphemeralKeySecret", null);
+        String customerId = call.getString("customerId", null);
+
+        if (verificationId == null && ephemeralKeySecret == null) {
+            String errorText = "Invalid Params. This method require verificationId or ephemeralKeySecret.";
+            notifyListenersFunction.accept(IdentityVerificationSheetEvent.FailedToLoad.getWebEventName(), new JSObject().put("error", errorText));
+            call.reject(errorText);
+            return;
+        }
+
+        notifyListenersFunction.accept(IdentityVerificationSheetEvent.Loaded.getWebEventName(), emptyObject);
+        call.resolve();
+    }
+
+    public void presentIdentityVerificationSheet(final PluginCall call) {
+        try {
+            verificationSheet.present(this.verificationId, this.ephemeralKeySecret);
+        } catch (Exception ex) {
+            call.reject(ex.getLocalizedMessage(), ex);
+        }
+    }
+}

--- a/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/identityverification/IdentityVerificationSheetExecutor.java
@@ -58,7 +58,7 @@ public class IdentityVerificationSheetExecutor extends Executor {
     public void onVerificationCompleted(Bridge bridge, String callbackId) {
         PluginCall call = bridge.getSavedCall(callbackId);
         notifyListenersFunction.accept(IdentityVerificationSheetEvent.Completed.getWebEventName(), emptyObject);
-        call.resolve();
+        call.resolve(new JSObject().put("identityVerificationResult", IdentityVerificationSheetEvent.Completed.getWebEventName()));
     }
 
     public void onVerificationCancelled(Bridge bridge, String callbackId) {

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		03FC29A292ACC40490383A1F /* Pods_Plugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B2A61DA5A1F2DD4F959604D /* Pods_Plugin.framework */; };
 		20C0B05DCFC8E3958A738AF2 /* Pods_PluginTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6753A823D3815DB436415E3 /* Pods_PluginTests.framework */; };
+		4FB4AFE429ADDA53003EBECD /* IdentityVerificationSheet in Resources */ = {isa = PBXBuildFile; fileRef = 4FB4AFE329ADDA53003EBECD /* IdentityVerificationSheet */; };
 		50ADFF92201F53D600D50D53 /* Plugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50ADFF88201F53D600D50D53 /* Plugin.framework */; };
 		50ADFF97201F53D600D50D53 /* StripePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ADFF96201F53D600D50D53 /* StripePluginTests.swift */; };
 		50ADFF99201F53D600D50D53 /* StripePlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ADFF8B201F53D600D50D53 /* StripePlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -35,6 +36,7 @@
 
 /* Begin PBXFileReference section */
 		3B2A61DA5A1F2DD4F959604D /* Pods_Plugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Plugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FB4AFE329ADDA53003EBECD /* IdentityVerificationSheet */ = {isa = PBXFileReference; lastKnownFileType = folder; path = IdentityVerificationSheet; sourceTree = "<group>"; };
 		50ADFF88201F53D600D50D53 /* Plugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Plugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50ADFF8B201F53D600D50D53 /* StripePlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripePlugin.h; sourceTree = "<group>"; };
 		50ADFF8C201F53D600D50D53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 		50ADFF8A201F53D600D50D53 /* Plugin */ = {
 			isa = PBXGroup;
 			children = (
+				4FB4AFE329ADDA53003EBECD /* IdentityVerificationSheet */,
 				DB9491A526D9FC9600E48032 /* ApplePay */,
 				DB280E4026AD432500AAEA30 /* PaymentFlow */,
 				DB16470A269C455D00E31818 /* PaymentSheet */,
@@ -262,6 +265,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DB9491A626D9FC9600E48032 /* ApplePay in Resources */,
+				4FB4AFE429ADDA53003EBECD /* IdentityVerificationSheet in Resources */,
 				DB15233A2663D401003F8BF2 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -303,15 +307,27 @@
 				"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Capacitor/Capacitor.framework",
 				"${BUILT_PRODUCTS_DIR}/CapacitorCordova/Cordova.framework",
-				"${BUILT_PRODUCTS_DIR}/Stripe/Stripe.framework",
+				"${BUILT_PRODUCTS_DIR}/StripeApplePay/StripeApplePay.framework",
+				"${BUILT_PRODUCTS_DIR}/StripeCameraCore/StripeCameraCore.framework",
 				"${BUILT_PRODUCTS_DIR}/StripeCore/StripeCore.framework",
+				"${BUILT_PRODUCTS_DIR}/StripeIdentity/StripeIdentity.framework",
+				"${BUILT_PRODUCTS_DIR}/StripePaymentSheet/StripePaymentSheet.framework",
+				"${BUILT_PRODUCTS_DIR}/StripePayments/StripePayments.framework",
+				"${BUILT_PRODUCTS_DIR}/StripePaymentsUI/StripePaymentsUI.framework",
+				"${BUILT_PRODUCTS_DIR}/StripeUICore/StripeUICore.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Capacitor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cordova.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Stripe.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripeApplePay.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripeCameraCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripeCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripeIdentity.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripePaymentSheet.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripePayments.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripePaymentsUI.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StripeUICore.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Plugin/IdentityVerificationSheet/IdentityVerificationSheetEvents.swift
+++ b/ios/Plugin/IdentityVerificationSheet/IdentityVerificationSheetEvents.swift
@@ -1,0 +1,7 @@
+public enum IdentityVerificationSheetEvents: String {
+    case Loaded = "identityVerificationSheetLoaded"
+    case FailedToLoad = "identityVerificationSheetFailedToLoad"
+    case Completed = "identityVerificationSheetCompleted"
+    case Canceled = "identityVerificationSheetCanceled"
+    case Failed = "identityVerificationSheetFailed"
+}

--- a/ios/Plugin/IdentityVerificationSheet/IdentityVerificationSheetExecutor.swift
+++ b/ios/Plugin/IdentityVerificationSheet/IdentityVerificationSheetExecutor.swift
@@ -32,7 +32,6 @@ class IdentityVerificationSheetExecutor: NSObject {
     }
 
     func presentIdentityVerificationSheet(_ call: CAPPluginCall) {
-
         DispatchQueue.main.async {
             if let rootViewController = self.plugin?.getRootVC() {
                 self.identityVerificationSheet!.present(from: rootViewController, completion: { result in
@@ -41,20 +40,20 @@ class IdentityVerificationSheetExecutor: NSObject {
                         // The user has completed uploading their documents.
                         // Let them know that the verification is processing.
                         print("Verification Flow Completed!")
-                        self.plugin?.notifyListeners(PaymentSheetEvents.Completed.rawValue, data: [:])
-                        call.resolve(["identityVerificationResult": PaymentSheetEvents.Completed.rawValue])
+                        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Completed.rawValue, data: [:])
+                        call.resolve(["identityVerificationResult": IdentityVerificationSheetEvents.Completed.rawValue])
                     case .flowCanceled:
                         // The user did not complete uploading their documents.
                         // You should allow them to try again.
                         print("Verification Flow Canceled!")
-                        self.plugin?.notifyListeners(PaymentSheetEvents.Canceled.rawValue, data: [:])
-                        call.reject(PaymentSheetEvents.Canceled.rawValue)
+                        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Canceled.rawValue, data: [:])
+                        call.reject(IdentityVerificationSheetEvents.Canceled.rawValue)
                     case .flowFailed(let error):
                         // If the flow fails, you should display the localized error
                         // message to your user using error.localizedDescription
                         print("Verification Flow Failed!")
                         print(error.localizedDescription)
-                        self.plugin?.notifyListeners(PaymentSheetEvents.Failed.rawValue, data: ["error": error.localizedDescription])
+                        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Failed.rawValue, data: ["error": error.localizedDescription])
                         call.reject(error.localizedDescription)
                     }
                 })

--- a/ios/Plugin/IdentityVerificationSheet/IdentityVerificationSheetExecutor.swift
+++ b/ios/Plugin/IdentityVerificationSheet/IdentityVerificationSheetExecutor.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Capacitor
+import StripeIdentity
+
+class IdentityVerificationSheetExecutor: NSObject {
+    public weak var plugin: StripePlugin?
+    var identityVerificationSheet: IdentityVerificationSheet?
+
+    func createIdentityVerificationSheet(_ call: CAPPluginCall) {
+        let verificationId = call.getString("verificationId") ?? nil
+        let ephemeralKeySecret = call.getString("ephemeralKeySecret") ?? nil
+
+        if verificationId == nil || ephemeralKeySecret == nil {
+            let errorText = "Invalid Params. this method require verificationId or ephemeralKeySecret."
+            self.plugin?.notifyListeners(IdentityVerificationSheetEvents.FailedToLoad.rawValue, data: ["error": errorText])
+            call.reject(errorText)
+            return
+        }
+
+        // Configure a square brand logo. Recommended image size is 32 x 32 points.
+        let configuration = IdentityVerificationSheet.Configuration(
+            brandLogo: UIImage(named: "AppIcon")!
+        )
+        self.identityVerificationSheet = IdentityVerificationSheet(
+            verificationSessionId: verificationId!,
+            ephemeralKeySecret: ephemeralKeySecret!,
+            configuration: configuration
+        )
+
+        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Loaded.rawValue, data: [:])
+        call.resolve([:])
+    }
+
+    func presentIdentityVerificationSheet(_ call: CAPPluginCall) {
+
+        DispatchQueue.main.async {
+            if let rootViewController = self.plugin?.getRootVC() {
+                self.identityVerificationSheet!.present(from: rootViewController, completion: { result in
+                    switch result {
+                    case .flowCompleted:
+                        // The user has completed uploading their documents.
+                        // Let them know that the verification is processing.
+                        print("Verification Flow Completed!")
+                        self.plugin?.notifyListeners(PaymentSheetEvents.Completed.rawValue, data: [:])
+                        call.resolve(["identityVerificationResult": PaymentSheetEvents.Completed.rawValue])
+                    case .flowCanceled:
+                        // The user did not complete uploading their documents.
+                        // You should allow them to try again.
+                        print("Verification Flow Canceled!")
+                        self.plugin?.notifyListeners(PaymentSheetEvents.Canceled.rawValue, data: [:])
+                        call.reject(PaymentSheetEvents.Canceled.rawValue)
+                    case .flowFailed(let error):
+                        // If the flow fails, you should display the localized error
+                        // message to your user using error.localizedDescription
+                        print("Verification Flow Failed!")
+                        print(error.localizedDescription)
+                        self.plugin?.notifyListeners(PaymentSheetEvents.Failed.rawValue, data: ["error": error.localizedDescription])
+                        call.reject(error.localizedDescription)
+                    }
+                })
+            }
+        }
+    }
+}

--- a/ios/Plugin/StripePlugin.m
+++ b/ios/Plugin/StripePlugin.m
@@ -17,4 +17,6 @@ CAP_PLUGIN(StripePlugin, "Stripe",
            CAP_PLUGIN_METHOD(isGooglePayAvailable, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(createGooglePay, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(presentGooglePay, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(createIdentityVerificationSheet, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(presentIdentityVerificationSheet, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/StripePlugin.swift
+++ b/ios/Plugin/StripePlugin.swift
@@ -7,11 +7,13 @@ import PassKit
 @objc(StripePlugin)
 public class StripePlugin: CAPPlugin {
     private let paymentSheetExecutor = PaymentSheetExecutor()
+    private let identityVerificationSheetExecutor = IdentityVerificationSheetExecutor()
     private let paymentFlowExecutor = PaymentFlowExecutor()
     private let applePayExecutor = ApplePayExecutor()
 
     @objc func initialize(_ call: CAPPluginCall) {
         self.paymentSheetExecutor.plugin = self
+        self.identityVerificationSheetExecutor.plugin = self
         self.paymentFlowExecutor.plugin = self
         self.applePayExecutor.plugin = self
 
@@ -37,6 +39,7 @@ public class StripePlugin: CAPPlugin {
 
     @objc func handleURLCallback(_ call: CAPPluginCall) {
         self.paymentSheetExecutor.plugin = self
+        self.identityVerificationSheetExecutor.plugin = self
         self.paymentFlowExecutor.plugin = self
         self.applePayExecutor.plugin = self
 
@@ -65,6 +68,14 @@ public class StripePlugin: CAPPlugin {
 
     @objc func presentPaymentSheet(_ call: CAPPluginCall) {
         self.paymentSheetExecutor.presentPaymentSheet(call)
+    }
+
+    @objc func createIdentityVerificationSheet(_ call: CAPPluginCall) {
+        self.identityVerificationSheetExecutor.createIdentityVerificationSheet(call)
+    }
+
+    @objc func presentIdentityVerificationSheet(_ call: CAPPluginCall) {
+        self.identityVerificationSheetExecutor.presentIdentityVerificationSheet(call)
     }
 
     @objc func createPaymentFlow(_ call: CAPPluginCall) {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -7,6 +7,7 @@ def capacitor_pods
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
   pod 'StripePaymentSheet', '23.3.2'
   pod 'StripeApplePay', '23.3.2'
+  pod 'StripeIdentity', '23.3.2'
 end
 
 target 'Plugin' do

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,6 @@
 import type { ApplePayDefinitions } from './applepay';
 import type { GooglePayDefinitions } from './googlepay';
+import type { IdentityVerificationSheetDefinitions } from './identityverificationsheet';
 import type { PaymentFlowDefinitions } from './paymentflow';
 import type { PaymentSheetDefinitions } from './paymentsheet';
 
@@ -7,9 +8,10 @@ export * from './applepay/index';
 export * from './googlepay/index';
 export * from './paymentflow/index';
 export * from './paymentsheet/index';
+export * from './identityverificationsheet/index';
 export * from './shared/index';
 
-type StripeDefinitions = PaymentSheetDefinitions & PaymentFlowDefinitions & ApplePayDefinitions & GooglePayDefinitions;
+type StripeDefinitions = PaymentSheetDefinitions & PaymentFlowDefinitions & ApplePayDefinitions & GooglePayDefinitions & IdentityVerificationSheetDefinitions;
 
 export interface StripePlugin extends StripeDefinitions {
   initialize(opts: StripeInitializationOptions): Promise<void>;

--- a/src/identityverificationsheet/identity-verification-sheet-definitions.interface.ts
+++ b/src/identityverificationsheet/identity-verification-sheet-definitions.interface.ts
@@ -1,0 +1,41 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
+import type {IdentityVerificationSheetEventsEnum, IdentityVerificationSheetResultInterface} from './identity-verification-sheet-events.enum';
+
+export interface CreateIdentityVerificationSheetOption {
+  verificationId: string; 
+  ephemeralKeySecret: string;
+}
+
+
+export interface IdentityVerificationSheetDefinitions {
+  createIdentityVerificationSheet(options: CreateIdentityVerificationSheetOption): Promise<void>;
+  presentIdentityVerificationSheet(): Promise<{
+    identityVerificationResult: IdentityVerificationSheetResultInterface;
+  }>;
+
+  addListener(
+    eventName: IdentityVerificationSheetEventsEnum.Loaded,
+    listenerFunc: () => void,
+  ): PluginListenerHandle;
+
+  addListener(
+    eventName: IdentityVerificationSheetEventsEnum.FailedToLoad,
+    listenerFunc: (error: string) => void,
+  ): PluginListenerHandle;
+
+  addListener(
+    eventName: IdentityVerificationSheetEventsEnum.Completed,
+    listenerFunc: () => void,
+  ): PluginListenerHandle;
+
+  addListener(
+    eventName: IdentityVerificationSheetEventsEnum.Canceled,
+    listenerFunc: () => void,
+  ): PluginListenerHandle;
+
+  addListener(
+    eventName: IdentityVerificationSheetEventsEnum.Failed,
+    listenerFunc: (error: string) => void,
+  ): PluginListenerHandle;
+}

--- a/src/identityverificationsheet/identity-verification-sheet-events.enum.ts
+++ b/src/identityverificationsheet/identity-verification-sheet-events.enum.ts
@@ -1,0 +1,12 @@
+export enum IdentityVerificationSheetEventsEnum {
+    Loaded = "identityVerificationSheetLoaded",
+    FailedToLoad = "identityVerificationSheetFailedToLoad",
+    Completed = "identityVerificationSheetCompleted",
+    Canceled = "identityVerificationSheetCanceled",
+    Failed = "identityVerificationSheetFailed"
+}
+
+export type IdentityVerificationSheetResultInterface =
+    IdentityVerificationSheetEventsEnum.Completed
+    | IdentityVerificationSheetEventsEnum.Canceled
+    | IdentityVerificationSheetEventsEnum.Failed

--- a/src/identityverificationsheet/index.ts
+++ b/src/identityverificationsheet/index.ts
@@ -1,0 +1,2 @@
+export * from './identity-verification-sheet-events.enum';
+export * from './identity-verification-sheet-definitions.interface';

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,16 +1,18 @@
 import { WebPlugin } from '@capacitor/core';
+import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 import type { Components } from '@stripe-elements/stripe-elements';
 import type { FormSubmitEvent } from '@stripe-elements/stripe-elements/dist/types/interfaces';
 import type { HTMLStencilElement } from '@stripe-elements/stripe-elements/dist/types/stencil-public-runtime';
-import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
 
 import type {
   ApplePayResultInterface,
   CreateApplePayOption,
   CreateGooglePayOption,
+  CreateIdentityVerificationSheetOption,
   CreatePaymentFlowOption,
   CreatePaymentSheetOption,
   GooglePayResultInterface,
+  IdentityVerificationSheetResultInterface,
   PaymentFlowResultInterface,
   PaymentSheetResultInterface,
   StripeInitializationOptions,
@@ -53,6 +55,15 @@ export class StripeWeb extends WebPlugin implements StripePlugin {
     if (options.stripeAccount) {
       this.stripeAccount = options.stripeAccount;
     }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createIdentityVerificationSheet(_options: CreateIdentityVerificationSheetOption): Promise<void> {
+      // TODO: what is web.ts for?
+  }
+    
+  presentIdentityVerificationSheet(): Promise<{ identityVerificationResult: IdentityVerificationSheetResultInterface; }> {
+    throw new Error('Method not implemented.');
   }
 
   async createPaymentSheet(options: CreatePaymentSheetOption): Promise<void> {


### PR DESCRIPTION
I've added [Stripe Identity functionality](https://stripe.com/docs/identity/verify-identity-documents) to the plugin for both Android & iOS. Web is not supported.

- Adds `createIdentityVerificationSheet` and `presentIdentityVerificationSheet`
- A 32x32 icon is required by Stripe Identity - this implementation passes through the Android or iOS app icon
- Per [integration documentation](https://stripe.com/docs/identity/verify-identity-documents) a `VerificationSession` and an `EphemeralKey` needs to be created server-side before calling `createIdentityVerificationSheet` which takes those values as parameters:
    ```typescript
    const { ephemeralKeySecret, verificationId } = await createVerificationSession()

    await Stripe.createIdentityVerificationSheet({
      ephemeralKeySecret,
      verificationId,
    })

    try {
      await Stripe.presentIdentityVerificationSheet()
    } catch (e: any) {
      switch (e) {
        case IdentityVerificationSheetEventsEnum.Canceled:
          console.log('Verification canceled')
          break
        case IdentityVerificationSheetEventsEnum.Failed:
          console.log('Verification failed')
          break
        default:
          console.log('Unknown error')
          break
      }
    }
    ```
- Note that [Stripe Identity](https://stripe.com/identity) is currently available only to USA/UK Stripe accounts.

## Android

https://user-images.githubusercontent.com/6289998/222327412-76a210e6-6651-4939-8645-dde78f33ae54.mp4

## iOS

https://user-images.githubusercontent.com/6289998/222326844-3bd72b7c-8489-45ce-a156-157dfea94084.mp4

