### PR TITLE
Add support for getting billing info from Google Pay

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -21,6 +21,8 @@ import com.stripe.android.identity.IdentityVerificationSheet;
 import com.stripe.android.paymentsheet.PaymentSheet;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 @NativePlugin(name = "Stripe", requestCodes = { 9972, 50000, 50001, 6000 })
 public class StripePlugin extends Plugin {
 
@@ -75,7 +77,19 @@ public class StripePlugin extends Plugin {
             this.googlePayExecutor.googlePayLauncher =
                 new GooglePayLauncher(
                     getActivity(),
-                    new GooglePayLauncher.Config(metaData.googlePayEnvironment, metaData.countryCode, metaData.displayName),
+                    new GooglePayLauncher.Config(
+                        metaData.googlePayEnvironment,
+                        metaData.countryCode,
+                        metaData.displayName,
+                        metaData.emailAddressRequired,
+                        new GooglePayLauncher.BillingAddressConfig(
+                            metaData.billingAddressRequired,
+                            Objects.equals(metaData.billingAddressFormat, "Full")
+                                ? GooglePayLauncher.BillingAddressConfig.Format.Full
+                                : GooglePayLauncher.BillingAddressConfig.Format.Min,
+                            metaData.phoneNumberRequired
+                        )
+                    ),
                     (boolean isReady) -> this.googlePayExecutor.isAvailable = isReady,
                     (@NotNull GooglePayLauncher.Result result) ->
                         this.googlePayExecutor.onGooglePayResult(bridge, googlePayCallbackId, result)

--- a/android/src/main/java/com/getcapacitor/community/stripe/helper/MetaData.java
+++ b/android/src/main/java/com/getcapacitor/community/stripe/helper/MetaData.java
@@ -15,6 +15,10 @@ public class MetaData {
     public String countryCode;
     public String displayName;
     public String stripeAccount;
+    public Boolean emailAddressRequired;
+    public Boolean phoneNumberRequired;
+    public Boolean billingAddressRequired;
+    public String billingAddressFormat;
     public GooglePayEnvironment googlePayEnvironment;
 
     public boolean enableIdentifier;
@@ -32,6 +36,10 @@ public class MetaData {
             countryCode = appInfo.metaData.getString("com.getcapacitor.community.stripe.country_code");
             displayName = appInfo.metaData.getString("com.getcapacitor.community.stripe.merchant_display_name");
             stripeAccount = appInfo.metaData.getString("com.getcapacitor.community.stripe.stripe_account");
+            emailAddressRequired = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.email_address_required");
+            phoneNumberRequired = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.phone_number_required");
+            billingAddressRequired = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.billing_address_required");
+            billingAddressFormat = appInfo.metaData.getString("com.getcapacitor.community.stripe.billing_address_format");
             enableIdentifier = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.enableIdentifier");
 
             boolean isTest = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.google_pay_is_testing");


### PR DESCRIPTION
Added metadata options to specify what, if any, billing info to require from Google Pay. Add the following entries to `strings.xml` in the Android project to enable additional data:

```
<bool name="email_address_required">true</bool>
<bool name="phone_number_required">true</bool>
<bool name="billing_address_required">true</bool>
<string name="billing_address_format">Full</string>
```

Billing address format can be set to `Full` or `Min`. If the metadata properties are omitted, the data will simply not be requested (same as current plugin behavior).