### PR TITLE
Update build.gradle kotlin jvmTarget to 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    
+    kotlinOptions {
+        jvmTarget=17
+    }
 }
 
 repositories {


### PR DESCRIPTION
Because some times kotlin read jvm 18 but the java still 17 wil cause error:

 * What went wrong: 
 Execution failed for task ':capacitor-community-stripe:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 18) jvm target compatibility should be set to the same Java version. Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain