### PR TITLE
[Identity] Update readme and the native versions with latest minor

### DIFF
--- a/packages/identity/CapacitorCommunityStripeIdentity.podspec
+++ b/packages/identity/CapacitorCommunityStripeIdentity.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripeIdentity', '23.4.0'
+  s.dependency 'StripeIdentity', '~> 23.4.0'
   s.swift_version = '5.1'
 end

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -19,7 +19,13 @@ change base application theme to `Theme.MaterialComponents.DayNight` at `res/val
 ```
 
 parent can be any MaterialComponents. [See here for other options](https://m2.material.io/develop/android/theming/dark/).
-All process is here: https://github.com/capacitor-community/stripe/commit/f514d893e9193bed2edbaf52c0d3ed1d534c7890asU
+see more details on Stripe's native Android SDK page [here](https://stripe.com/docs/identity/verify-identity-documents?platform=android&type=new-integration#set-up-material-theme).
+
+
+### Initialize iOS
+
+set up camera authorization by adding `NSCameraUsageDescription` in `Info.plist` and add a string value that explains the usage.
+see more details on Stripe's native iOS SDK page [here](https://stripe.com/docs/identity/verify-identity-documents?platform=ios&type=new-integration#set-up-camera-authorization).
 
 ## Usage
 
@@ -32,7 +38,7 @@ await StripeIdentity.create({
   ephemeralKeySecret,
   verificationId,
 });
-const result = await Stripe.present();
+const result = await StripeIdentity.present();
 ```
 
 ## API

--- a/packages/identity/android/build.gradle
+++ b/packages/identity/android/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 
-    implementation 'com.stripe:identity:20.28.2'
+    implementation 'com.stripe:identity:20.28.+'
     implementation 'com.google.android.gms:play-services-wallet:19.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
Thanks for building the capacitor plugin for Stripe Identity! This PR fixed a small typo in README and added a section to add camera permission on iOS, also added details links to the native SDK.

For our react native wrapper, we pick up the latest Android/iOS minor version instead of using a fixed version, also made similar changes here.