### PR TITLE
Add extra billing details to payment sheet

### DIFF
--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -669,40 +669,52 @@ iOS Only
 
 #### CreatePaymentFlowOption
 
-| Prop                             | Type                                       | Description                                                                                      | Default                 |
-| -------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------- |
-| **`paymentIntentClientSecret`**  | <code>string</code>                        | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
-| **`setupIntentClientSecret`**    | <code>string</code>                        | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
-| **`customerEphemeralKeySecret`** | <code>string</code>                        | Any documentation call 'ephemeralKey'                                                            |                         |
-| **`customerId`**                 | <code>string</code>                        | Any documentation call 'customer'                                                                |                         |
-| **`enableApplePay`**             | <code>boolean</code>                       | If you set payment method ApplePay, this set true                                                | <code>false</code>      |
-| **`applePayMerchantId`**         | <code>string</code>                        | If set enableApplePay false, Plugin ignore here.                                                 |                         |
-| **`enableGooglePay`**            | <code>boolean</code>                       | If you set payment method GooglePay, this set true                                               | <code>false</code>      |
-| **`GooglePayIsTesting`**         | <code>boolean</code>                       |                                                                                                  | <code>false,</code>     |
-| **`countryCode`**                | <code>string</code>                        | use ApplePay and GooglePay. If set enableApplePay and enableGooglePay false, Plugin ignore here. | <code>"US"</code>       |
-| **`merchantDisplayName`**        | <code>string</code>                        |                                                                                                  | <code>"App Name"</code> |
-| **`returnURL`**                  | <code>string</code>                        |                                                                                                  | <code>""</code>         |
-| **`style`**                      | <code>'alwaysLight' \| 'alwaysDark'</code> | iOS Only                                                                                         | <code>undefined</code>  |
-| **`withZipCode`**                | <code>boolean</code>                       | Platform: Web only Show ZIP code field.                                                          | <code>true</code>       |
+| Prop                                        | Type                                                                                                    | Description                                                                                      | Default                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------- |
+| **`paymentIntentClientSecret`**             | <code>string</code>                                                                                     | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
+| **`setupIntentClientSecret`**               | <code>string</code>                                                                                     | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
+| **`billingDetailsCollectionConfiguration`** | <code><a href="#billingdetailscollectionconfiguration">BillingDetailsCollectionConfiguration</a></code> | Optional billingDetailsCollectionConfiguration                                                   |                         |
+| **`customerEphemeralKeySecret`**            | <code>string</code>                                                                                     | Any documentation call 'ephemeralKey'                                                            |                         |
+| **`customerId`**                            | <code>string</code>                                                                                     | Any documentation call 'customer'                                                                |                         |
+| **`enableApplePay`**                        | <code>boolean</code>                                                                                    | If you set payment method ApplePay, this set true                                                | <code>false</code>      |
+| **`applePayMerchantId`**                    | <code>string</code>                                                                                     | If set enableApplePay false, Plugin ignore here.                                                 |                         |
+| **`enableGooglePay`**                       | <code>boolean</code>                                                                                    | If you set payment method GooglePay, this set true                                               | <code>false</code>      |
+| **`GooglePayIsTesting`**                    | <code>boolean</code>                                                                                    |                                                                                                  | <code>false,</code>     |
+| **`countryCode`**                           | <code>string</code>                                                                                     | use ApplePay and GooglePay. If set enableApplePay and enableGooglePay false, Plugin ignore here. | <code>"US"</code>       |
+| **`merchantDisplayName`**                   | <code>string</code>                                                                                     |                                                                                                  | <code>"App Name"</code> |
+| **`returnURL`**                             | <code>string</code>                                                                                     |                                                                                                  | <code>""</code>         |
+| **`style`**                                 | <code>'alwaysLight' \| 'alwaysDark'</code>                                                              | iOS Only                                                                                         | <code>undefined</code>  |
+| **`withZipCode`**                           | <code>boolean</code>                                                                                    | Platform: Web only Show ZIP code field.                                                          | <code>true</code>       |
+
+
+#### BillingDetailsCollectionConfiguration
+
+| Prop          | Type                                                                    | Description                                                          |
+| ------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **`email`**   | <code><a href="#collectionmode">CollectionMode</a></code>               | Configuration for how billing details are collected during checkout. |
+| **`name`**    | <code><a href="#collectionmode">CollectionMode</a></code>               |                                                                      |
+| **`phone`**   | <code><a href="#collectionmode">CollectionMode</a></code>               |                                                                      |
+| **`address`** | <code><a href="#addresscollectionmode">AddressCollectionMode</a></code> |                                                                      |
 
 
 #### CreatePaymentSheetOption
 
-| Prop                             | Type                                       | Description                                                                                      | Default                 |
-| -------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------- |
-| **`paymentIntentClientSecret`**  | <code>string</code>                        | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
-| **`setupIntentClientSecret`**    | <code>string</code>                        | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
-| **`customerEphemeralKeySecret`** | <code>string</code>                        | Any documentation call 'ephemeralKey'                                                            |                         |
-| **`customerId`**                 | <code>string</code>                        | Any documentation call 'customer'                                                                |                         |
-| **`enableApplePay`**             | <code>boolean</code>                       | If you set payment method ApplePay, this set true                                                | <code>false</code>      |
-| **`applePayMerchantId`**         | <code>string</code>                        | If set enableApplePay false, Plugin ignore here.                                                 |                         |
-| **`enableGooglePay`**            | <code>boolean</code>                       | If you set payment method GooglePay, this set true                                               | <code>false</code>      |
-| **`GooglePayIsTesting`**         | <code>boolean</code>                       |                                                                                                  | <code>false,</code>     |
-| **`countryCode`**                | <code>string</code>                        | use ApplePay and GooglePay. If set enableApplePay and enableGooglePay false, Plugin ignore here. | <code>"US"</code>       |
-| **`merchantDisplayName`**        | <code>string</code>                        |                                                                                                  | <code>"App Name"</code> |
-| **`returnURL`**                  | <code>string</code>                        |                                                                                                  | <code>""</code>         |
-| **`style`**                      | <code>'alwaysLight' \| 'alwaysDark'</code> | iOS Only                                                                                         | <code>undefined</code>  |
-| **`withZipCode`**                | <code>boolean</code>                       | Platform: Web only Show ZIP code field.                                                          | <code>true</code>       |
+| Prop                                        | Type                                                                                                    | Description                                                                                      | Default                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------- |
+| **`paymentIntentClientSecret`**             | <code>string</code>                                                                                     | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
+| **`setupIntentClientSecret`**               | <code>string</code>                                                                                     | Any documentation call 'paymentIntent' Set paymentIntentClientSecret or setupIntentClientSecret  |                         |
+| **`billingDetailsCollectionConfiguration`** | <code><a href="#billingdetailscollectionconfiguration">BillingDetailsCollectionConfiguration</a></code> | Optional billingDetailsCollectionConfiguration                                                   |                         |
+| **`customerEphemeralKeySecret`**            | <code>string</code>                                                                                     | Any documentation call 'ephemeralKey'                                                            |                         |
+| **`customerId`**                            | <code>string</code>                                                                                     | Any documentation call 'customer'                                                                |                         |
+| **`enableApplePay`**                        | <code>boolean</code>                                                                                    | If you set payment method ApplePay, this set true                                                | <code>false</code>      |
+| **`applePayMerchantId`**                    | <code>string</code>                                                                                     | If set enableApplePay false, Plugin ignore here.                                                 |                         |
+| **`enableGooglePay`**                       | <code>boolean</code>                                                                                    | If you set payment method GooglePay, this set true                                               | <code>false</code>      |
+| **`GooglePayIsTesting`**                    | <code>boolean</code>                                                                                    |                                                                                                  | <code>false,</code>     |
+| **`countryCode`**                           | <code>string</code>                                                                                     | use ApplePay and GooglePay. If set enableApplePay and enableGooglePay false, Plugin ignore here. | <code>"US"</code>       |
+| **`merchantDisplayName`**                   | <code>string</code>                                                                                     |                                                                                                  | <code>"App Name"</code> |
+| **`returnURL`**                             | <code>string</code>                                                                                     |                                                                                                  | <code>""</code>         |
+| **`style`**                                 | <code>'alwaysLight' \| 'alwaysDark'</code>                                                              | iOS Only                                                                                         | <code>undefined</code>  |
+| **`withZipCode`**                           | <code>boolean</code>                                                                                    | Platform: Web only Show ZIP code field.                                                          | <code>true</code>       |
 
 
 #### StripeInitializationOptions
@@ -748,6 +760,20 @@ iOS Only
 #### GooglePayResultInterface
 
 <code><a href="#googlepayeventsenum">GooglePayEventsEnum.Completed</a> | <a href="#googlepayeventsenum">GooglePayEventsEnum.Canceled</a> | <a href="#googlepayeventsenum">GooglePayEventsEnum.Failed</a></code>
+
+
+#### CollectionMode
+
+Billing details collection options.
+
+<code>'automatic' | 'always'</code>
+
+
+#### AddressCollectionMode
+
+Billing details collection options.
+
+<code>'automatic' | 'full'</code>
 
 
 #### PaymentFlowResultInterface

--- a/packages/payment/ios/Plugin/PaymentSheet/PaymentSheetExecutor.swift
+++ b/packages/payment/ios/Plugin/PaymentSheet/PaymentSheetExecutor.swift
@@ -62,6 +62,25 @@ class PaymentSheetExecutor: NSObject {
             configuration.customer = .init(id: customerId!, ephemeralKeySecret: customerEphemeralKeySecret!)
         }
 
+        let billingDetailsCollectionConfiguration = call.getObject("billingDetailsCollectionConfiguration") ?? nil
+        if billingDetailsCollectionConfiguration != nil {
+            billingDetailsCollectionConfiguration?.forEach({ (key: String, value: JSValue) in
+                let val: String = value as? String ?? "automatic"
+                switch key {
+                case "email":
+                    configuration.billingDetailsCollectionConfiguration.email = getCollectionModeValue(mode: val)
+                case "name":
+                    configuration.billingDetailsCollectionConfiguration.name = getCollectionModeValue(mode: val)
+                case "phone":
+                    configuration.billingDetailsCollectionConfiguration.phone = getCollectionModeValue(mode: val)
+                case "address":
+                    configuration.billingDetailsCollectionConfiguration.address = getAddressCollectionModeValue(mode: val)
+                default:
+                    return
+                }
+            })
+        }
+
         if setupIntentClientSecret != nil {
             self.paymentSheet = PaymentSheet(setupIntentClientSecret: setupIntentClientSecret!, configuration: configuration)
         } else {
@@ -90,6 +109,24 @@ class PaymentSheetExecutor: NSObject {
                     }
                 }
             }
+        }
+    }
+
+    func getCollectionModeValue(mode: String) -> PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode {
+        switch mode {
+        case "always":
+            return .always
+        default:
+            return .automatic
+        }
+    }
+
+    func getAddressCollectionModeValue(mode: String) -> PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode {
+        switch mode {
+        case "full":
+            return .full
+        default:
+            return .automatic
         }
     }
 }

--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -32,7 +32,31 @@ export interface CreatePaymentFlowOption extends BasePaymentOption {
   setupIntentClientSecret?: string;
 }
 
+/**
+ * Billing details collection options.
+ */
+export type AddressCollectionMode = 'automatic' | 'full';
+
+/**
+ * Billing details collection options.
+ */
+export type CollectionMode = 'automatic' | 'always';
+
+interface BillingDetailsCollectionConfiguration {
+  /**
+   * Configuration for how billing details are collected during checkout.
+   */
+  email?: CollectionMode,
+  name?: CollectionMode,
+  phone?: CollectionMode,
+  address?: AddressCollectionMode
+}
+
 export interface BasePaymentOption {
+  /**
+   * Optional billingDetailsCollectionConfiguration
+   */
+  billingDetailsCollectionConfiguration?: BillingDetailsCollectionConfiguration;
 
   /**
    * Any documentation call 'ephemeralKey'


### PR DESCRIPTION
This PR adds the ability to include additional billing details (email, name, phone, address) to show up on the PaymentSheet.
However, the available options for email, phone, name collection are only `always` and `automatic` and for address `full` and `automatic`. This has been done to minimize the impact of the changes and to also be scalable if other collection modes are to be made available.