### PR TITLE
feat: add logic to allow countries and block others

### DIFF
--- a/packages/payment/ios/Plugin/ApplePay/ApplePayExecutor.swift
+++ b/packages/payment/ios/Plugin/ApplePay/ApplePayExecutor.swift
@@ -9,7 +9,7 @@ class ApplePayExecutor: NSObject, ApplePayContextDelegate {
     private var payCallId: String?
     private var paymentRequest: PKPaymentRequest?
     private var allowedCountries: [String] = []
-    private var allowedCountriesError: String = ""
+    private var allowedCountriesErrorDescription: String = ""
 
     func isApplePayAvailable(_ call: CAPPluginCall) {
         if !StripeAPI.deviceSupportsApplePay() {
@@ -50,7 +50,7 @@ class ApplePayExecutor: NSObject, ApplePayContextDelegate {
         let merchantIdentifier = call.getString("merchantIdentifier") ?? ""
         let requiredShippingContactFields = call.getArray("requiredShippingContactFields", String.self) ?? [""]
         self.allowedCountries = call.getArray("allowedCountries", String.self) ?? []
-        self.allowedCountriesError = call.getString("allowedCountriesError") ?? "Country not allowed"
+        self.allowedCountriesErrorDescription = call.getString("allowedCountriesErrorDescription") ?? "Country not allowed"
 
         let paymentRequest = StripeAPI.paymentRequest(withMerchantIdentifier: merchantIdentifier, country: call.getString("countryCode", "US"), currency: call.getString("currency", "USD"))
         paymentRequest.paymentSummaryItems = paymentSummaryItems
@@ -145,7 +145,7 @@ extension ApplePayExecutor {
             let addressIsoCountry = (contact.postalAddress?.isoCountryCode as? String ?? "").lowercased();
             if !self.allowedCountries.contains(addressIsoCountry) {
                 handler(PKPaymentRequestShippingContactUpdate.init(
-                    errors: [PKPaymentRequest.paymentShippingAddressInvalidError(withKey: CNPostalAddressISOCountryCodeKey, localizedDescription: self.allowedCountriesError)],
+                    errors: [PKPaymentRequest.paymentShippingAddressInvalidError(withKey: CNPostalAddressISOCountryCodeKey, localizedDescription: self.allowedCountriesErrorDescription)],
                     paymentSummaryItems: self.paymentRequest?.paymentSummaryItems ?? [],
                     shippingMethods: self.paymentRequest?.shippingMethods ?? []))
                 return

--- a/packages/payment/ios/Plugin/ApplePay/ApplePayExecutor.swift
+++ b/packages/payment/ios/Plugin/ApplePay/ApplePayExecutor.swift
@@ -8,6 +8,8 @@ class ApplePayExecutor: NSObject, ApplePayContextDelegate {
     var appleClientSecret: String = ""
     private var payCallId: String?
     private var paymentRequest: PKPaymentRequest?
+    private var allowedCountries: [String] = []
+    private var allowedCountriesError: String = ""
 
     func isApplePayAvailable(_ call: CAPPluginCall) {
         if !StripeAPI.deviceSupportsApplePay() {
@@ -47,6 +49,9 @@ class ApplePayExecutor: NSObject, ApplePayContextDelegate {
 
         let merchantIdentifier = call.getString("merchantIdentifier") ?? ""
         let requiredShippingContactFields = call.getArray("requiredShippingContactFields", String.self) ?? [""]
+        self.allowedCountries = call.getArray("allowedCountries", String.self) ?? []
+        self.allowedCountriesError = call.getString("allowedCountriesError") ?? "Country not allowed"
+
         let paymentRequest = StripeAPI.paymentRequest(withMerchantIdentifier: merchantIdentifier, country: call.getString("countryCode", "US"), currency: call.getString("currency", "USD"))
         paymentRequest.paymentSummaryItems = paymentSummaryItems
         if requiredShippingContactFields.count > 0 {
@@ -134,6 +139,18 @@ extension ApplePayExecutor {
         handler(PKPaymentRequestShippingContactUpdate.init(paymentSummaryItems: []))
         let jsonArray = self.transformPKContactToJSON(contact: contact)
         self.plugin?.notifyListeners(ApplePayEvents.DidSelectShippingContact.rawValue, data: ["contact": jsonArray])
+
+        // Check allowed countries
+        if (!self.allowedCountries.isEmpty) {
+            let addressIsoCountry = (contact.postalAddress?.isoCountryCode as? String ?? "").lowercased();
+            if !self.allowedCountries.contains(addressIsoCountry) {
+                handler(PKPaymentRequestShippingContactUpdate.init(
+                    errors: [PKPaymentRequest.paymentShippingAddressInvalidError(withKey: CNPostalAddressISOCountryCodeKey, localizedDescription: self.allowedCountriesError)],
+                    paymentSummaryItems: self.paymentRequest?.paymentSummaryItems ?? [],
+                    shippingMethods: self.paymentRequest?.shippingMethods ?? []))
+                return
+            }
+        }
     }
 
     func applePayContext(_ context: STPApplePayContext, didCreatePaymentMethod paymentMethod: StripeAPI.PaymentMethod, paymentInformation: PKPayment, completion: @escaping STPIntentClientSecretCompletionBlock) {

--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -136,6 +136,8 @@ export interface CreateApplePayOption {
   countryCode: string;
   currency: string;
   requiredShippingContactFields?: ('postalAddress' | 'phoneNumber' | 'emailAddress' | 'name')[];
+  allowedCountries?: string[];
+  allowedCountriesError?: string;
 }
 
 export interface CreateGooglePayOption {

--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -137,7 +137,7 @@ export interface CreateApplePayOption {
   currency: string;
   requiredShippingContactFields?: ('postalAddress' | 'phoneNumber' | 'emailAddress' | 'name')[];
   allowedCountries?: string[];
-  allowedCountriesError?: string;
+  allowedCountriesErrorDescription?: string;
 }
 
 export interface CreateGooglePayOption {


### PR DESCRIPTION
Hello again @rdlabo.

I'm Rubén García de Longoria, a little over a year ago I made [this PR](https://github.com/capacitor-community/stripe/pull/210) PR to add the shipping address functionality.

Now I come to propose a new improvement that we have implemented in our App.

### The problem:

Our App sells ecological products to different countries. The final price varies depending on the destination country.

The user has selected a destination country in the App, but the Apple Pay address may be from a different country.

The problem is that the plugin, although it has the didSelectShippingContact event to detect this change in JavaScript, there is no possibility of modifying the figure in Apple Pay once opened. It would have to be developed natively within the plugin.

### The solution:

What we do is prohibit the user from selecting addresses from a country other than the destination country once the Apple Pay interface is opened.

I have added two new properties to the plugin:

![Captura de pantalla 2023-11-28 a las 15 29 26](https://github.com/capacitor-community/stripe/assets/84543810/53b01f7b-c495-493e-8fa4-7dd3df8fae24)

allowedCountries: An array of ISO codes of countries for which we allow sales.

allowedCountriesError: A string for the message to display if an incorrect country is selected. By default it shows "Please enter a valid address"

![Captura de pantalla 2023-11-28 a las 15 22 32](https://github.com/capacitor-community/stripe/assets/84543810/10990cfb-b67a-4b6c-b477-4ca706848f1b)

An example of use would be the following:

![Captura de pantalla 2023-11-28 a las 15 31 04](https://github.com/capacitor-community/stripe/assets/84543810/3ff32fe6-8527-4aba-9243-fefd8a6149f0)

Below I leave you a couple of videos where you can see the problem, in our case we limit the payment to addresses in the same country.

First the user is in Spain and can only choose addresses in Spain

https://github.com/capacitor-community/stripe/assets/84543810/8046ae60-12a9-450b-9e0f-32fd134cb938

Then the user is in Germany and can only choose German addresses.

https://github.com/capacitor-community/stripe/assets/84543810/644b2ff5-383c-41f1-92b1-61511b4f6fb7

---------------

We would love to help other users with the same problem.

We have thought that the most generic solution is to include an array of allowed IOS, but we can discuss new options if they are considered necessary.

If this PR was accepted it would be of great help to us and our users.

**As always, happy to collaborate with you.**

**All the best**



