### PR TITLE
fix(payment): default android version must be support 33

### DIFF
--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -610,14 +610,16 @@ iOS Only
 
 #### CreateApplePayOption
 
-| Prop                                | Type                                                                          |
-| ----------------------------------- | ----------------------------------------------------------------------------- |
-| **`paymentIntentClientSecret`**     | <code>string</code>                                                           |
-| **`paymentSummaryItems`**           | <code>{ label: string; amount: number; }[]</code>                             |
-| **`merchantIdentifier`**            | <code>string</code>                                                           |
-| **`countryCode`**                   | <code>string</code>                                                           |
-| **`currency`**                      | <code>string</code>                                                           |
-| **`requiredShippingContactFields`** | <code>('postalAddress' \| 'phoneNumber' \| 'emailAddress' \| 'name')[]</code> |
+| Prop                                   | Type                                                                          |
+| -------------------------------------- | ----------------------------------------------------------------------------- |
+| **`paymentIntentClientSecret`**        | <code>string</code>                                                           |
+| **`paymentSummaryItems`**              | <code>{ label: string; amount: number; }[]</code>                             |
+| **`merchantIdentifier`**               | <code>string</code>                                                           |
+| **`countryCode`**                      | <code>string</code>                                                           |
+| **`currency`**                         | <code>string</code>                                                           |
+| **`requiredShippingContactFields`**    | <code>('postalAddress' \| 'phoneNumber' \| 'emailAddress' \| 'name')[]</code> |
+| **`allowedCountries`**                 | <code>string[]</code>                                                         |
+| **`allowedCountriesErrorDescription`** | <code>string</code>                                                           |
 
 
 #### PluginListenerHandle

--- a/packages/payment/android/build.gradle
+++ b/packages/payment/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
-    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '20.32.+'
+    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '20.31.+'
     gsonVersion = project.hasProperty('gsonVersion') ? rootProject.ext.gsonVersion : '2.10.+'
 }
 

--- a/packages/payment/android/build.gradle
+++ b/packages/payment/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
-    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '20.34.+'
+    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '20.32.+'
     gsonVersion = project.hasProperty('gsonVersion') ? rootProject.ext.gsonVersion : '2.10.+'
 }
 

--- a/packages/payment/package.json
+++ b/packages/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/stripe",
-  "version": "5.4.2",
+  "version": "5.4.3-1",
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
Issue:
- https://github.com/capacitor-community/stripe/issues/331
- https://github.com/ionic-team/capacitor-plugins/issues/1994


Please try this version:

```
% npm install @capacitor-community/stripe@5.4.3-1
```