### PR TITLE
Revert "bump iOS to `~> 23.24.0` and Android to `20.38.+`"

### DIFF
--- a/packages/identity/CapacitorCommunityStripeIdentity.podspec
+++ b/packages/identity/CapacitorCommunityStripeIdentity.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripeIdentity', '~> 23.24.0'
+  s.dependency 'StripeIdentity', '~> 23.23.0'
   s.swift_version = '5.1'
 end

--- a/packages/identity/ios/Podfile
+++ b/packages/identity/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'StripeIdentity', '~> 23.24.0'
+  pod 'StripeIdentity', '~> 23.23.0'
 end
 
 target 'Plugin' do

--- a/packages/payment/CapacitorCommunityStripe.podspec
+++ b/packages/payment/CapacitorCommunityStripe.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripePaymentSheet', '~> 23.24.0'
-  s.dependency 'StripeApplePay', '~> 23.24.0'
+  s.dependency 'StripePaymentSheet', '~> 23.23.0'
+  s.dependency 'StripeApplePay', '~> 23.23.0'
   s.swift_version = '5.1'
 end

--- a/packages/payment/ios/Podfile
+++ b/packages/payment/ios/Podfile
@@ -5,8 +5,8 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'StripePaymentSheet', '~> 23.24.0'
-  pod 'StripeApplePay', '~> 23.24.0'
+  pod 'StripePaymentSheet', '~> 23.23.0'
+  pod 'StripeApplePay', '~> 23.23.0'
 end
 
 target 'Plugin' do


### PR DESCRIPTION
Reverts capacitor-community/stripe#337

This pull request is require iOS 15+. 

> minimum deployment target