### PR TITLE
feat(terminal): add option to set string token

### DIFF
--- a/demo/angular/src/app/terminal/terminal.page.ts
+++ b/demo/angular/src/app/terminal/terminal.page.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {IonicModule, Platform} from '@ionic/angular';
@@ -153,9 +153,18 @@ export class TerminalPage {
     const eventKeys = Object.keys(TerminalEventsEnum);
     eventKeys.forEach(key => {
       const handler = StripeTerminal.addListener(TerminalEventsEnum[key], () => {
+        console.log(key);
         this.helper.updateItem(this.eventItems, TerminalEventsEnum[key], true);
       });
       this.listenerHandlers.push(handler);
+      if (key === 'RequestedConnectionToken') {
+        this.listenerHandlers.push(StripeTerminal.addListener(TerminalEventsEnum.RequestedConnectionToken, async () => {
+          const { secret } = await firstValueFrom(this.http.post<{
+            secret: string;
+          }>(environment.api + 'connection/token', {}));
+          StripeTerminal.setConnectionToken({ token: secret });
+        }));
+      }
     });
 
     if (type === 'happyPath') {
@@ -164,7 +173,7 @@ export class TerminalPage {
       this.eventItems =  JSON.parse(JSON.stringify(cancelPathItems));
     }
 
-    await StripeTerminal.initialize({ tokenProviderEndpoint: environment.api + 'connection/token', isTest: readerType === TerminalConnectTypes.TapToPay })
+    await StripeTerminal.initialize({ isTest: readerType === TerminalConnectTypes.TapToPay })
       .then(() => this.helper.updateItem(this.eventItems,'initialize', true))
       .catch(() => this.helper.updateItem(this.eventItems,'initialize', false));
 
@@ -224,6 +233,14 @@ export class TerminalPage {
         this.helper.updateItem(this.eventItems, TerminalEventsEnum[key], true);
       });
       this.listenerHandlers.push(handler);
+      if (key === 'RequestedConnectionToken') {
+        this.listenerHandlers.push(StripeTerminal.addListener(TerminalEventsEnum.RequestedConnectionToken, async () => {
+          const { secret } = await firstValueFrom(this.http.post<{
+            secret: string;
+          }>(environment.api + 'connection/token', {}));
+          StripeTerminal.setConnectionToken({ token: secret });
+        }));
+      }
     });
 
     this.eventItems =  JSON.parse(JSON.stringify(checkDiscoverMethodItems));

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -56,6 +56,8 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 
 ## Usage
 
+### use native http client for getting a token
+
 ```typescript
 (async ()=> {
   /**
@@ -73,12 +75,36 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 });
 ```
 
+### set string token
+
+```typescript
+(async ()=> {
+  // run before StripeTerminal.initialize
+  StripeTerminal.addListener(TerminalEventsEnum.RequestedConnectionToken, async () => {
+    const { token } = (await fetch("https://example.com/token")).json();
+    StripeTerminal.setConnectionToken({ token });
+  });
+});
+(async ()=> {
+  await StripeTerminal.initialize({ isTest: true })
+  const { readers } = await StripeTerminal.discoverReaders({
+    type: TerminalConnectTypes.TapToPay,
+    locationId: "**************",
+  });
+  await StripeTerminal.connectReader({
+    reader: readers[0],
+  });
+  await StripeTerminal.collect({ paymentIntent: "**************" });
+});
+````
+
 ## API
 
 <docgen-index>
 
 * [`initialize(...)`](#initialize)
 * [`discoverReaders(...)`](#discoverreaders)
+* [`setConnectionToken(...)`](#setconnectiontoken)
 * [`connectReader(...)`](#connectreader)
 * [`getConnectedReader()`](#getconnectedreader)
 * [`disconnectReader()`](#disconnectreader)
@@ -86,6 +112,7 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 * [`collect(...)`](#collect)
 * [`cancelCollect()`](#cancelcollect)
 * [`addListener(TerminalEventsEnum.Loaded, ...)`](#addlistenerterminaleventsenumloaded)
+* [`addListener(TerminalEventsEnum.RequestedConnectionToken, ...)`](#addlistenerterminaleventsenumrequestedconnectiontoken)
 * [`addListener(TerminalEventsEnum.DiscoveredReaders, ...)`](#addlistenerterminaleventsenumdiscoveredreaders)
 * [`addListener(TerminalEventsEnum.ConnectedReader, ...)`](#addlistenerterminaleventsenumconnectedreader)
 * [`addListener(TerminalEventsEnum.Completed, ...)`](#addlistenerterminaleventsenumcompleted)
@@ -103,12 +130,12 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 ### initialize(...)
 
 ```typescript
-initialize(options: { tokenProviderEndpoint: string; isTest: boolean; }) => Promise<void>
+initialize(options: { tokenProviderEndpoint?: string; isTest: boolean; }) => Promise<void>
 ```
 
-| Param         | Type                                                             |
-| ------------- | ---------------------------------------------------------------- |
-| **`options`** | <code>{ tokenProviderEndpoint: string; isTest: boolean; }</code> |
+| Param         | Type                                                              |
+| ------------- | ----------------------------------------------------------------- |
+| **`options`** | <code>{ tokenProviderEndpoint?: string; isTest: boolean; }</code> |
 
 --------------------
 
@@ -124,6 +151,19 @@ discoverReaders(options: { type: TerminalConnectTypes; locationId?: string; }) =
 | **`options`** | <code>{ type: <a href="#terminalconnecttypes">TerminalConnectTypes</a>; locationId?: string; }</code> |
 
 **Returns:** <code>Promise&lt;{ readers: ReaderInterface[]; }&gt;</code>
+
+--------------------
+
+
+### setConnectionToken(...)
+
+```typescript
+setConnectionToken(options: { token: string; }) => Promise<void>
+```
+
+| Param         | Type                            |
+| ------------- | ------------------------------- |
+| **`options`** | <code>{ token: string; }</code> |
 
 --------------------
 
@@ -202,6 +242,22 @@ addListener(eventName: TerminalEventsEnum.Loaded, listenerFunc: () => void) => P
 | ------------------ | ------------------------------------------------------------------------ |
 | **`eventName`**    | <code><a href="#terminaleventsenum">TerminalEventsEnum.Loaded</a></code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>                                               |
+
+**Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### addListener(TerminalEventsEnum.RequestedConnectionToken, ...)
+
+```typescript
+addListener(eventName: TerminalEventsEnum.RequestedConnectionToken, listenerFunc: () => void) => PluginListenerHandle
+```
+
+| Param              | Type                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| **`eventName`**    | <code><a href="#terminaleventsenum">TerminalEventsEnum.RequestedConnectionToken</a></code> |
+| **`listenerFunc`** | <code>() =&gt; void</code>                                                                 |
 
 **Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
@@ -322,15 +378,16 @@ addListener(eventName: TerminalEventsEnum.Failed, listenerFunc: () => void) => P
 
 #### TerminalEventsEnum
 
-| Members                       | Value                                          |
-| ----------------------------- | ---------------------------------------------- |
-| **`Loaded`**                  | <code>'terminalLoaded'</code>                  |
-| **`DiscoveredReaders`**       | <code>'terminalDiscoveredReaders'</code>       |
-| **`CancelDiscoveredReaders`** | <code>'terminalCancelDiscoveredReaders'</code> |
-| **`ConnectedReader`**         | <code>'terminalConnectedReader'</code>         |
-| **`DisconnectedReader`**      | <code>'terminalDisconnectedReader'</code>      |
-| **`Completed`**               | <code>'terminalCompleted'</code>               |
-| **`Canceled`**                | <code>'terminalCanceled'</code>                |
-| **`Failed`**                  | <code>'terminalFailed'</code>                  |
+| Members                        | Value                                           |
+| ------------------------------ | ----------------------------------------------- |
+| **`Loaded`**                   | <code>'terminalLoaded'</code>                   |
+| **`DiscoveredReaders`**        | <code>'terminalDiscoveredReaders'</code>        |
+| **`CancelDiscoveredReaders`**  | <code>'terminalCancelDiscoveredReaders'</code>  |
+| **`ConnectedReader`**          | <code>'terminalConnectedReader'</code>          |
+| **`DisconnectedReader`**       | <code>'terminalDisconnectedReader'</code>       |
+| **`Completed`**                | <code>'terminalCompleted'</code>                |
+| **`Canceled`**                 | <code>'terminalCanceled'</code>                 |
+| **`Failed`**                   | <code>'terminalFailed'</code>                   |
+| **`RequestedConnectionToken`** | <code>'terminalRequestedConnectionToken'</code> |
 
 </docgen-api>

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.java
@@ -2,9 +2,7 @@ package com.getcapacitor.community.stripe.terminal;
 
 import android.Manifest;
 import android.os.Build;
-
 import androidx.annotation.RequiresApi;
-
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -34,6 +32,11 @@ public class StripeTerminalPlugin extends Plugin {
     @PluginMethod
     public void initialize(PluginCall call) throws TerminalException {
         this._initialize(call);
+    }
+
+    @PluginMethod
+    public void setConnectionToken(PluginCall call) {
+        this.implementation.setConnectionToken(call);
     }
 
     @PermissionCallback

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/TerminalEvent.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/TerminalEvent.kt
@@ -9,4 +9,5 @@ enum class TerminalEnumEvent(val webEventName: String) {
     Completed("terminalCompleted"),
     Canceled("terminalCanceled"),
     Failed("terminalFailed"),
+    RequestedConnectionToken("terminalRequestedConnectionToken"),
 }

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/TokenProvider.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/TokenProvider.java
@@ -2,19 +2,20 @@ package com.getcapacitor.community.stripe.terminal;
 
 import android.content.Context;
 import android.util.Log;
-
 import androidx.core.util.Supplier;
-
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+import com.google.android.gms.common.util.BiConsumer;
 import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback;
 import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider;
 import com.stripe.stripeterminal.external.models.ConnectionTokenException;
-
+import java.util.Objects;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -22,49 +23,82 @@ public class TokenProvider implements ConnectionTokenProvider {
 
     protected Supplier<Context> contextSupplier;
     protected final String tokenProviderEndpoint;
+    protected BiConsumer<String, JSObject> notifyListenersFunction;
+    ConnectionTokenCallback pendingCallback = null;
 
-    public TokenProvider(Supplier<Context> contextSupplier, String tokenProviderEndpoint) {
+    public TokenProvider(
+        Supplier<Context> contextSupplier,
+        String tokenProviderEndpoint,
+        BiConsumer<String, JSObject> notifyListenersFunction
+    ) {
         this.contextSupplier = contextSupplier;
         this.tokenProviderEndpoint = tokenProviderEndpoint;
+        this.notifyListenersFunction = notifyListenersFunction;
+    }
+
+    public void setConnectionToken(PluginCall call) {
+        String token = call.getString("token", "");
+        if (pendingCallback != null) {
+            if (Objects.equals(token, "")) {
+                pendingCallback.onFailure(new ConnectionTokenException("Missing `token` is empty"));
+                call.reject("Missing `token` is empty");
+            } else {
+                pendingCallback.onSuccess(token);
+                call.resolve();
+            }
+            pendingCallback = null;
+        } else {
+            call.reject("Stripe Terminal do not pending fetchConnectionToken");
+        }
     }
 
     @Override
     public void fetchConnectionToken(ConnectionTokenCallback callback) {
-        try {
-            RequestQueue queue = Volley.newRequestQueue(this.contextSupplier.get());
-            StringRequest postRequest = new StringRequest(
-                Request.Method.POST,
-                this.tokenProviderEndpoint,
-                new Response.Listener<String>() {
-                    @Override
-                    public void onResponse(String response) {
-                        try {
-                            JSONObject jsonObject = new JSONObject(response);
-                            Log.d("TokenProvider", jsonObject.getString("secret"));
-                            callback.onSuccess(jsonObject.getString("secret"));
-                        } catch (JSONException e) {
+        if (Objects.equals(this.tokenProviderEndpoint, "")) {
+            pendingCallback = callback;
+            this.notifyListeners(TerminalEnumEvent.RequestedConnectionToken.getWebEventName(), new JSObject());
+        } else {
+            try {
+                RequestQueue queue = Volley.newRequestQueue(this.contextSupplier.get());
+                StringRequest postRequest = new StringRequest(
+                    Request.Method.POST,
+                    this.tokenProviderEndpoint,
+                    new Response.Listener<String>() {
+                        @Override
+                        public void onResponse(String response) {
+                            try {
+                                JSONObject jsonObject = new JSONObject(response);
+                                Log.d("TokenProvider", jsonObject.getString("secret"));
+                                callback.onSuccess(jsonObject.getString("secret"));
+                            } catch (JSONException e) {
+                                callback.onFailure(new ConnectionTokenException(Objects.requireNonNull(e.getLocalizedMessage())));
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    },
+                    new Response.ErrorListener() {
+                        @Override
+                        public void onErrorResponse(VolleyError e) {
                             throw new RuntimeException(e);
                         }
                     }
-                },
-                new Response.ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            ) {
-                //                @Override
-                //                protected Map<String,String> getParams(){
-                //                    Map<String,String> params = new HashMap<>();
-                //                    params.put("word","test");
-                //                    return params;
-                //                }
-            };
+                ) {
+                    //                @Override
+                    //                protected Map<String,String> getParams(){
+                    //                    Map<String,String> params = new HashMap<>();
+                    //                    params.put("word","test");
+                    //                    return params;
+                    //                }
+                };
 
-            queue.add(postRequest);
-        } catch (Exception e) {
-            callback.onFailure(new ConnectionTokenException("Failed to fetch connection token", e));
+                queue.add(postRequest);
+            } catch (Exception e) {
+                callback.onFailure(new ConnectionTokenException("Failed to fetch connection token", e));
+            }
         }
+    }
+
+    protected void notifyListeners(String eventName, JSObject data) {
+        notifyListenersFunction.accept(eventName, data);
     }
 }

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/helper/MetaData.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/helper/MetaData.java
@@ -3,9 +3,7 @@ package com.getcapacitor.community.stripe.terminal.helper;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-
 import androidx.core.util.Supplier;
-
 import com.getcapacitor.Logger;
 
 public class MetaData {

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/models/Executor.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/models/Executor.java
@@ -2,9 +2,7 @@ package com.getcapacitor.community.stripe.terminal.models;
 
 import android.app.Activity;
 import android.content.Context;
-
 import androidx.core.util.Supplier;
-
 import com.getcapacitor.JSObject;
 import com.google.android.gms.common.util.BiConsumer;
 

--- a/packages/terminal/ios/Plugin/StripeTerminalPlugin.m
+++ b/packages/terminal/ios/Plugin/StripeTerminalPlugin.m
@@ -5,6 +5,7 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(StripeTerminalPlugin, "StripeTerminal",
            CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setConnectionToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(discoverReaders, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(cancelDiscoverReaders, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(connectReader, CAPPluginReturnPromise);

--- a/packages/terminal/ios/Plugin/StripeTerminalPlugin.swift
+++ b/packages/terminal/ios/Plugin/StripeTerminalPlugin.swift
@@ -21,6 +21,10 @@ public class StripeTerminalPlugin: CAPPlugin {
         self.implementation.initialize(call)
     }
 
+    @objc func setConnectionToken(_ call: CAPPluginCall) {
+        self.implementation.setConnectionToken(call)
+    }
+
     @objc func discoverReaders(_ call: CAPPluginCall) {
         do {
             try self.implementation.discoverReaders(call)

--- a/packages/terminal/ios/Plugin/TerminalEvents.swift
+++ b/packages/terminal/ios/Plugin/TerminalEvents.swift
@@ -6,4 +6,5 @@ public enum TerminalEvents: String {
     case Completed = "terminalCompleted"
     case Canceled = "terminalCanceled"
     case Failed = "terminalFailed"
+    case RequestedConnectionToken = "terminalRequestedConnectionToken"
 }

--- a/packages/terminal/ios/PluginTests/StripeTerminalTests.swift
+++ b/packages/terminal/ios/PluginTests/StripeTerminalTests.swift
@@ -2,15 +2,6 @@ import XCTest
 @testable import Plugin
 
 class StripeTerminalTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
 
     func testEcho() {
         // This is an example of a functional test case for a plugin.

--- a/packages/terminal/src/definitions.ts
+++ b/packages/terminal/src/definitions.ts
@@ -18,7 +18,7 @@ export type ReaderInterface = {
 export * from './events.enum';
 export interface StripeTerminalPlugin {
   initialize(options: {
-    tokenProviderEndpoint: string;
+    tokenProviderEndpoint?: string;
     isTest: boolean;
   }): Promise<void>;
   discoverReaders(options: {
@@ -27,6 +27,7 @@ export interface StripeTerminalPlugin {
   }): Promise<{
     readers: ReaderInterface[];
   }>;
+  setConnectionToken(options: { token: string }): Promise<void>;
   connectReader(options: { reader: ReaderInterface }): Promise<void>;
   getConnectedReader(): Promise<{ reader: ReaderInterface | null }>;
   disconnectReader(): Promise<void>;
@@ -35,6 +36,10 @@ export interface StripeTerminalPlugin {
   cancelCollect(): Promise<void>;
   addListener(
     eventName: TerminalEventsEnum.Loaded,
+    listenerFunc: () => void,
+  ): PluginListenerHandle;
+  addListener(
+    eventName: TerminalEventsEnum.RequestedConnectionToken,
     listenerFunc: () => void,
   ): PluginListenerHandle;
   addListener(

--- a/packages/terminal/src/events.enum.ts
+++ b/packages/terminal/src/events.enum.ts
@@ -7,6 +7,7 @@ export enum TerminalEventsEnum {
   Completed = 'terminalCompleted',
   Canceled = 'terminalCanceled',
   Failed = 'terminalFailed',
+  RequestedConnectionToken = 'terminalRequestedConnectionToken',
 }
 
 export type TerminalResultInterface =

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -39,6 +39,10 @@ export class StripeTerminalWeb
     this.notifyListeners(TerminalEventsEnum.CancelDiscoveredReaders, null);
   }
 
+  async setConnectionToken(): Promise<void> {
+    console.log('setConnectionToken');
+  }
+
   async connectReader(options: { reader: ReaderInterface }): Promise<void> {
     console.log('connectReader', options);
     this.notifyListeners(TerminalEventsEnum.ConnectedReader, null);


### PR DESCRIPTION
close https://github.com/capacitor-community/stripe/issues/335

### use native http client for getting a token

```typescript
(async ()=> {
  /**
   * tokenProviderEndpoint: The URL of your backend to provide a token. Use Post request to get a token.
   */
  await StripeTerminal.initialize({ tokenProviderEndpoint: 'https://example.com/token', isTest: true })
  const { readers } = await StripeTerminal.discoverReaders({
    type: TerminalConnectTypes.TapToPay,
    locationId: "**************",
  });
  await StripeTerminal.connectReader({
    reader: readers[0],
  });
  await StripeTerminal.collect({ paymentIntent: "**************" });
});
```

### set string token

```typescript
(async ()=> {
  // run before StripeTerminal.initialize
  StripeTerminal.addListener(TerminalEventsEnum.RequestedConnectionToken, async () => {
    const { token } = (await fetch("https://example.com/token")).json();
    StripeTerminal.setConnectionToken({ token });
  });
});
(async ()=> {
  await StripeTerminal.initialize({ isTest: true })
  const { readers } = await StripeTerminal.discoverReaders({
    type: TerminalConnectTypes.TapToPay,
    locationId: "**************",
  });
  await StripeTerminal.connectReader({
    reader: readers[0],
  });
  await StripeTerminal.collect({ paymentIntent: "**************" });
});
````