### PR TITLE
feat(terminal): rename collect to collectPaymentMethod

### DIFF
--- a/demo/angular/android/app/src/main/AndroidManifest.xml
+++ b/demo/angular/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" android:minSdkVersion="31" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:minSdkVersion="31" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" android:minSdkVersion="31" />
 
     <application
         android:allowBackup="true"
@@ -62,12 +68,4 @@
 <!--        android:name="com.getcapacitor.community.stripe.stripe_account"-->
 <!--        android:value="@string/stripe_account"/>-->
     </application>
-
-    <!-- Permissions -->
-
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-  <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 </manifest>

--- a/demo/angular/android/variables.gradle
+++ b/demo/angular/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 26
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
     androidxActivityVersion = '1.7.0'
     androidxAppCompatVersion = '1.6.1'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/demo/angular/ios/App/Podfile.lock
+++ b/demo/angular/ios/App/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - Capacitor (5.0.0):
     - CapacitorCordova
-  - CapacitorCommunityStripe (5.4.4):
+  - CapacitorCommunityStripe (5.4.6):
     - Capacitor
     - StripeApplePay (~> 23.24.0)
     - StripePaymentSheet (~> 23.24.0)
-  - CapacitorCommunityStripeIdentity (5.4.4):
+  - CapacitorCommunityStripeIdentity (5.4.6):
     - Capacitor
     - StripeIdentity (~> 23.24.0)
-  - CapacitorCommunityStripeTerminal (5.4.4):
+  - CapacitorCommunityStripeTerminal (5.5.0-beta.1):
     - Capacitor
-    - StripeTerminal (~> 3.3.1)
+    - StripeTerminal (~> 3.4.0)
   - CapacitorCordova (5.0.0)
   - StripeApplePay (23.24.1):
     - StripeCore (= 23.24.1)
@@ -35,7 +35,7 @@ PODS:
     - StripeCore (= 23.24.1)
     - StripePayments (= 23.24.1)
     - StripeUICore (= 23.24.1)
-  - StripeTerminal (3.3.1)
+  - StripeTerminal (3.4.0)
   - StripeUICore (23.24.1):
     - StripeCore (= 23.24.1)
 
@@ -72,9 +72,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Capacitor: b332cb737d447561e854039fb72195206685dce2
-  CapacitorCommunityStripe: 5729a153eb5cb6ac28dab496afff3416471983b0
-  CapacitorCommunityStripeIdentity: 4dd105cfb8ef4b091d687fb05d88f60371bba4ce
-  CapacitorCommunityStripeTerminal: e7e725b9bbefed0500503105f930fd90394b6bd8
+  CapacitorCommunityStripe: 3fee1254742ce744f6576bda1fc899cfa053e797
+  CapacitorCommunityStripeIdentity: 3996571069f39e5c9820f15598e3ccf9c507f9a7
+  CapacitorCommunityStripeTerminal: add001625e3eee13be86a241fd59d56b4f0fa083
   CapacitorCordova: 4ea17670ee562680988a7ce9db68dee5160fe564
   StripeApplePay: ffc296e6eba1d9ce86e4b5c4733540bce6f1b3eb
   StripeCameraCore: 3459f80598a8cd2060ba3e28e647ea50a94912cd
@@ -83,7 +83,7 @@ SPEC CHECKSUMS:
   StripePayments: 4fdc6b22595887753851aee425dc9aafad39e8ef
   StripePaymentSheet: 9f433a11fa6578939c555b6a56c87b7a958845d6
   StripePaymentsUI: 42a4c50bd30a19c102685eeb7269a52c71a79bb3
-  StripeTerminal: 369ef0cf0b90d838f42be1a0b371475986f4b79f
+  StripeTerminal: bdca32b058179ff3595c7d886a1cc45d4e810c5c
   StripeUICore: 510afeb8f0cb8ba5f99563a23c5ad6cc7f58a007
 
 PODFILE CHECKSUM: 2430ef1d0136ea2c0f7e2696daff19ed8cd27595

--- a/demo/angular/src/app/terminal/terminal.page.ts
+++ b/demo/angular/src/app/terminal/terminal.page.ts
@@ -63,7 +63,7 @@ const happyPathItems: ITestItems[] = [
   },
   {
     type: 'method',
-    name: 'collect',
+    name: 'collectPaymentMethod',
   },
   {
     type: 'event',
@@ -110,11 +110,11 @@ const cancelPathItems: ITestItems[] = [
   },
   {
     type: 'method',
-    name: 'collect',
+    name: 'collectPaymentMethod',
   },
   {
     type: 'method',
-    name: 'cancelCollect',
+    name: 'cancelCollectPaymentMethod',
   },
   {
     type: 'event',
@@ -281,20 +281,20 @@ export class TerminalPage {
       true,
     );
 
-    await StripeTerminal.collect({ paymentIntent })
-      .then(() => this.helper.updateItem(this.eventItems, 'collect', true))
+    await StripeTerminal.collectPaymentMethod({ paymentIntent })
+      .then(() => this.helper.updateItem(this.eventItems, 'collectPaymentMethod', true))
       .catch(async (e) => {
-        await this.helper.updateItem(this.eventItems, 'collect', false);
+        await this.helper.updateItem(this.eventItems, 'collectPaymentMethod', false);
         throw e;
       });
 
     if (type === 'cancelPath') {
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      await StripeTerminal.cancelCollect().catch(async (e) => {
-        await this.helper.updateItem(this.eventItems, 'cancelCollect', false);
+      await StripeTerminal.cancelCollectPaymentMethod().catch(async (e) => {
+        await this.helper.updateItem(this.eventItems, 'cancelCollectPaymentMethod', false);
         throw e;
       });
-      await this.helper.updateItem(this.eventItems, 'cancelCollect', true);
+      await this.helper.updateItem(this.eventItems, 'cancelCollectPaymentMethod', true);
     } else {
       await StripeTerminal.confirmPaymentIntent();
       await this.helper.updateItem(

--- a/demo/angular/src/app/terminal/terminal.page.ts
+++ b/demo/angular/src/app/terminal/terminal.page.ts
@@ -342,6 +342,7 @@ export class TerminalPage {
       );
     }
 
+    await StripeTerminal.disconnectReader();
     this.listenerHandlers.forEach((handler) => handler.remove());
   }
 

--- a/demo/angular/src/environments/environment.ts
+++ b/demo/angular/src/environments/environment.ts
@@ -7,12 +7,3 @@ export const environment = {
   // api: 'http://localhost:3000/',
   api: 'https://j3x0ln9gj7.execute-api.ap-northeast-1.amazonaws.com/dev/',
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.

--- a/packages/terminal/CapacitorCommunityStripeTerminal.podspec
+++ b/packages/terminal/CapacitorCommunityStripeTerminal.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripeTerminal', '~> 3.3.1'
+  s.dependency 'StripeTerminal', '~> 3.4.0'
   s.swift_version = '5.1'
 end

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -126,6 +126,8 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 * [`addListener(TerminalEventsEnum.CollectedPaymentIntent, ...)`](#addlistenerterminaleventsenumcollectedpaymentintent)
 * [`addListener(TerminalEventsEnum.Canceled, ...)`](#addlistenerterminaleventsenumcanceled)
 * [`addListener(TerminalEventsEnum.Failed, ...)`](#addlistenerterminaleventsenumfailed)
+* [`collect(...)`](#collect)
+* [`cancelCollect(...)`](#cancelcollect)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 * [Enums](#enums)
@@ -373,6 +375,38 @@ addListener(eventName: TerminalEventsEnum.Failed, listenerFunc: () => void) => P
 | **`listenerFunc`** | <code>() =&gt; void</code>                                               |
 
 **Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
+
+--------------------
+
+
+### collect(...)
+
+```typescript
+collect(options: { paymentIntent: string; }) => Promise<void>
+```
+
+This method has been deprecated and replaced by the `collectPaymentMethod`.
+Similarly, note that TerminalEvents.Completed is now obsolete.
+And, method `confirmPaymentIntent` added to be executed after `collectPaymentMethod` is executed.
+
+| Param         | Type                                    |
+| ------------- | --------------------------------------- |
+| **`options`** | <code>{ paymentIntent: string; }</code> |
+
+--------------------
+
+
+### cancelCollect(...)
+
+```typescript
+cancelCollect(options: { paymentIntent: string; }) => Promise<void>
+```
+
+This method has been deprecated and replaced by the `cancelCollectPaymentMethod`.
+
+| Param         | Type                                    |
+| ------------- | --------------------------------------- |
+| **`options`** | <code>{ paymentIntent: string; }</code> |
 
 --------------------
 

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -126,8 +126,6 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 * [`addListener(TerminalEventsEnum.CollectedPaymentIntent, ...)`](#addlistenerterminaleventsenumcollectedpaymentintent)
 * [`addListener(TerminalEventsEnum.Canceled, ...)`](#addlistenerterminaleventsenumcanceled)
 * [`addListener(TerminalEventsEnum.Failed, ...)`](#addlistenerterminaleventsenumfailed)
-* [`collect(...)`](#collect)
-* [`cancelCollect(...)`](#cancelcollect)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 * [Enums](#enums)
@@ -375,38 +373,6 @@ addListener(eventName: TerminalEventsEnum.Failed, listenerFunc: () => void) => P
 | **`listenerFunc`** | <code>() =&gt; void</code>                                               |
 
 **Returns:** <code><a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
-
---------------------
-
-
-### collect(...)
-
-```typescript
-collect(options: { paymentIntent: string; }) => Promise<void>
-```
-
-This method has been deprecated and replaced by the `collectPaymentMethod`.
-Similarly, note that TerminalEvents.Completed is now obsolete.
-And, method `confirmPaymentIntent` added to be executed after `collectPaymentMethod` is executed.
-
-| Param         | Type                                    |
-| ------------- | --------------------------------------- |
-| **`options`** | <code>{ paymentIntent: string; }</code> |
-
---------------------
-
-
-### cancelCollect(...)
-
-```typescript
-cancelCollect(options: { paymentIntent: string; }) => Promise<void>
-```
-
-This method has been deprecated and replaced by the `cancelCollectPaymentMethod`.
-
-| Param         | Type                                    |
-| ------------- | --------------------------------------- |
-| **`options`** | <code>{ paymentIntent: string; }</code> |
 
 --------------------
 

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -5,7 +5,7 @@ We have confirmed that it works well in the demo project. Please refer to https:
 
 - [x] Tap To Pay
 - [x] Internet
-- [ ] Bluetooth
+- [x] Bluetooth
 - [ ] USB
 
 ## Install

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -72,7 +72,7 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
     reader: readers[0],
   });
   // Collect payment intent
-  await StripeTerminal.collect({ paymentIntent: "**************" });
+  await StripeTerminal.collectPaymentMethod({ paymentIntent: "**************" });
   // Process and confirm payment intent
   await StripeTerminal.confirmPaymentIntent();
 });
@@ -98,7 +98,7 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
     reader: readers[0],
   });
   // Collect payment intent
-  await StripeTerminal.collect({ paymentIntent: "**************" });
+  await StripeTerminal.collectPaymentMethod({ paymentIntent: "**************" });
   // Process and confirm payment intent
   await StripeTerminal.confirmPaymentIntent();
 });
@@ -115,8 +115,8 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
 * [`getConnectedReader()`](#getconnectedreader)
 * [`disconnectReader()`](#disconnectreader)
 * [`cancelDiscoverReaders()`](#canceldiscoverreaders)
-* [`collect(...)`](#collect)
-* [`cancelCollect()`](#cancelcollect)
+* [`collectPaymentMethod(...)`](#collectpaymentmethod)
+* [`cancelCollectPaymentMethod()`](#cancelcollectpaymentmethod)
 * [`confirmPaymentIntent()`](#confirmpaymentintent)
 * [`addListener(TerminalEventsEnum.Loaded, ...)`](#addlistenerterminaleventsenumloaded)
 * [`addListener(TerminalEventsEnum.RequestedConnectionToken, ...)`](#addlistenerterminaleventsenumrequestedconnectiontoken)
@@ -218,10 +218,10 @@ cancelDiscoverReaders() => Promise<void>
 --------------------
 
 
-### collect(...)
+### collectPaymentMethod(...)
 
 ```typescript
-collect(options: { paymentIntent: string; }) => Promise<void>
+collectPaymentMethod(options: { paymentIntent: string; }) => Promise<void>
 ```
 
 | Param         | Type                                    |
@@ -231,10 +231,10 @@ collect(options: { paymentIntent: string; }) => Promise<void>
 --------------------
 
 
-### cancelCollect()
+### cancelCollectPaymentMethod()
 
 ```typescript
-cancelCollect() => Promise<void>
+cancelCollectPaymentMethod() => Promise<void>
 ```
 
 --------------------

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -50,7 +50,7 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
   ext {
 -    minSdkVersion = 22
 -    compileSdkVersion = 33
-+    minSdkVersion = 26
++    minSdkVersion = 30
 +    compileSdkVersion = 34
 ```
 

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -6,7 +6,7 @@ We have confirmed that it works well in the demo project. Please refer to https:
 - [x] Tap To Pay
 - [x] Internet
 - [x] Bluetooth
-- [ ] USB
+- [x] USB
 
 ## Install
 
@@ -27,8 +27,9 @@ Add permissions to your `android/app/src/main/AndroidManifest.xml` file:
 + <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 + <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
 + <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-+ <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 + <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
++ <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
++ <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 ```
 
 If used in conjunction with the `@capacitor-community/stripe` plugin, the following settings may be necessary

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -76,6 +76,8 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
   await StripeTerminal.collectPaymentMethod({ paymentIntent: "**************" });
   // Process and confirm payment intent
   await StripeTerminal.confirmPaymentIntent();
+  // disconnect reader
+  await StripeTerminal.disconnectReader();
 });
 ```
 
@@ -102,6 +104,8 @@ And update minSdkVersion to 26 And compileSdkVersion to 34 in your `android/app/
   await StripeTerminal.collectPaymentMethod({ paymentIntent: "**************" });
   // Process and confirm payment intent
   await StripeTerminal.confirmPaymentIntent();
+  // disconnect reader
+  await StripeTerminal.disconnectReader();
 });
 ````
 

--- a/packages/terminal/android/build.gradle
+++ b/packages/terminal/android/build.gradle
@@ -7,7 +7,7 @@ ext {
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
     volleyVersion = project.hasProperty('volleyVersion') ? rootProject.ext.volleyVersion : '1.2.1'
     stripeterminalLocalmobileVersion = project.hasProperty('stripeterminalLocalmobileVersion') ? rootProject.ext.stripeterminalLocalmobileVersion : '3.0.+'
-    stripeterminalCoreVersion = project.hasProperty('stripeterminalCoreVersion') ? rootProject.ext.stripeterminalCoreVersion : '3.3.+'
+    stripeterminalCoreVersion = project.hasProperty('stripeterminalCoreVersion') ? rootProject.ext.stripeterminalCoreVersion : '3.4.+'
 }
 
 buildscript {

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.java
@@ -24,6 +24,7 @@ import com.stripe.stripeterminal.external.callable.DiscoveryListener;
 import com.stripe.stripeterminal.external.callable.PaymentIntentCallback;
 import com.stripe.stripeterminal.external.callable.ReaderCallback;
 import com.stripe.stripeterminal.external.callable.ReaderListener;
+import com.stripe.stripeterminal.external.callable.ReaderReconnectionListener;
 import com.stripe.stripeterminal.external.callable.TerminalListener;
 import com.stripe.stripeterminal.external.models.CardPresentDetails;
 import com.stripe.stripeterminal.external.models.CollectConfiguration;
@@ -240,9 +241,33 @@ public class StripeTerminal extends Executor {
             return;
         }
 
-        LocalMobileConnectionConfiguration config = new LocalMobileConnectionConfiguration(this.locationId);
+        LocalMobileConnectionConfiguration config = new LocalMobileConnectionConfiguration(
+            this.locationId,
+            true,
+            this.localMobileReaderReconnectionListener
+        );
         Terminal.getInstance().connectLocalMobileReader(this.readers.get(reader.getInteger("index")), config, this.readerCallback(call));
     }
+
+    ReaderReconnectionListener localMobileReaderReconnectionListener = new ReaderReconnectionListener() {
+        @Override
+        public void onReaderReconnectStarted(@NonNull Reader reader, @NonNull Cancelable cancelReconnect) {
+            // 1. Notified at the start of a reconnection attempt
+            // Use cancelable to stop reconnection at any time
+        }
+
+        @Override
+        public void onReaderReconnectSucceeded(@NonNull Reader reader) {
+            // 2. Notified when reader reconnection succeeds
+            // App is now connected
+        }
+
+        @Override
+        public void onReaderReconnectFailed(@NonNull Reader reader) {
+            // 3. Notified when reader reconnection fails
+            // App is now disconnected
+        }
+    };
 
     private void connectInternetReader(final PluginCall call) {
         JSObject reader = call.getObject("reader");
@@ -333,7 +358,6 @@ public class StripeTerminal extends Executor {
         }
     };
 
-    // Step 3 - we've collected the payment method, so it's time to process the payment
     private final PaymentIntentCallback collectPaymentMethodCallback = new PaymentIntentCallback() {
         @Override
         public void onSuccess(PaymentIntent paymentIntent) {

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.java
@@ -287,7 +287,7 @@ public class StripeTerminal extends Executor {
         }
     }
 
-    public void collect(final PluginCall call) {
+    public void collectPaymentMethod(final PluginCall call) {
         if (call.getString("paymentIntent") == null) {
             call.reject("The value of paymentIntent is not set correctly.");
             return;
@@ -296,7 +296,7 @@ public class StripeTerminal extends Executor {
         Terminal.getInstance().retrievePaymentIntent(call.getString("paymentIntent"), createPaymentIntentCallback);
     }
 
-    public void cancelCollect(final PluginCall call) {
+    public void cancelCollectPaymentMethod(final PluginCall call) {
         if (this.collectCancelable == null || this.collectCancelable.isCompleted()) {
             call.resolve();
             return;

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.java
@@ -2,6 +2,8 @@ package com.getcapacitor.community.stripe.terminal;
 
 import android.Manifest;
 import android.os.Build;
+import android.util.Log;
+
 import androidx.annotation.RequiresApi;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -48,7 +50,7 @@ public class StripeTerminalPlugin extends Plugin {
         if (getPermissionState("location") == PermissionState.GRANTED) {
             this._initialize(call);
         } else {
-            call.reject("Permission is required to get location");
+            requestPermissionForAlias("location", call, "locationPermsCallback");
         }
     }
 
@@ -57,7 +59,7 @@ public class StripeTerminalPlugin extends Plugin {
         if (getPermissionState("bluetooth_old") == PermissionState.GRANTED) {
             this._initialize(call);
         } else {
-            call.reject("Permission is required to get bluetooth_old");
+            requestPermissionForAlias("bluetooth_old", call, "bluetoothOldPermsCallback");
         }
     }
 
@@ -66,7 +68,7 @@ public class StripeTerminalPlugin extends Plugin {
         if (getPermissionState("bluetooth") == PermissionState.GRANTED) {
             this._initialize(call);
         } else {
-            call.reject("Permission is required to get bluetooth");
+            requestPermissionForAlias("bluetooth", call, "bluetoothPermsCallback");
         }
     }
 
@@ -78,6 +80,9 @@ public class StripeTerminalPlugin extends Plugin {
         } else if (Build.VERSION.SDK_INT > 30 && getPermissionState("bluetooth") != PermissionState.GRANTED) {
             requestPermissionForAlias("bluetooth", call, "bluetoothPermsCallback");
         } else {
+            Log.d("Capacitor:permission location", getPermissionState("location").toString());
+            Log.d("Capacitor:permission bluetooth_old", getPermissionState("bluetooth_old").toString());
+            Log.d("Capacitor:permission bluetooth", getPermissionState("bluetooth").toString());
             this.implementation.initialize(call);
         }
     }

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.java
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.java
@@ -93,13 +93,13 @@ public class StripeTerminalPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void collect(PluginCall call) {
-        this.implementation.collect(call);
+    public void collectPaymentMethod(PluginCall call) {
+        this.implementation.collectPaymentMethod(call);
     }
 
     @PluginMethod
-    public void cancelCollect(final PluginCall call) {
-        this.implementation.cancelCollect(call);
+    public void cancelCollectPaymentMethod(final PluginCall call) {
+        this.implementation.cancelCollectPaymentMethod(call);
     }
 
     @PluginMethod

--- a/packages/terminal/ios/Plugin/StripeTerminal.swift
+++ b/packages/terminal/ios/Plugin/StripeTerminal.swift
@@ -105,6 +105,9 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, LocalMobileReaderDeleg
             self.connectLocalMobileReader(call)
         } else if self.type == .internet {
             self.connectInternetReader(call)
+        } else {
+            // if self.type === DiscoveryMethod.bluetoothScan
+            self.connectBluetoothReader(call)
         }
     }
 
@@ -169,7 +172,7 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, LocalMobileReaderDeleg
     }
 
     private func connectBluetoothReader(_ call: CAPPluginCall) {
-        let config = try! BluetoothConnectionConfigurationBuilder(locationId: "{{LOCATION_ID}}").build()
+        let config = try! BluetoothConnectionConfigurationBuilder(locationId: self.locationId!).build()
         let reader: JSObject = call.getObject("reader")!
         let index: Int = reader["index"] as! Int
 

--- a/packages/terminal/ios/Plugin/StripeTerminal.swift
+++ b/packages/terminal/ios/Plugin/StripeTerminal.swift
@@ -183,7 +183,7 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, LocalMobileReaderDeleg
         }
     }
 
-    public func collect(_ call: CAPPluginCall) {
+    public func collectPaymentMethod(_ call: CAPPluginCall) {
         Terminal.shared.retrievePaymentIntent(clientSecret: call.getString("paymentIntent")!) { retrieveResult, retrieveError in
             if let error = retrieveError {
                 print("retrievePaymentIntent failed: \(error)")
@@ -202,7 +202,7 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, LocalMobileReaderDeleg
         }
     }
 
-    public func cancelCollect(_ call: CAPPluginCall) {
+    public func cancelCollectPaymentMethod(_ call: CAPPluginCall) {
         if let cancelable = self.collectCancelable {
             cancelable.cancel { error in
                 if let error = error {

--- a/packages/terminal/ios/Plugin/StripeTerminalPlugin.m
+++ b/packages/terminal/ios/Plugin/StripeTerminalPlugin.m
@@ -11,7 +11,7 @@ CAP_PLUGIN(StripeTerminalPlugin, "StripeTerminal",
            CAP_PLUGIN_METHOD(connectReader, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getConnectedReader, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(disconnectReader, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(collect, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(cancelCollect, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(collectPaymentMethod, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(cancelCollectPaymentMethod, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(confirmPaymentIntent, CAPPluginReturnPromise);
 )

--- a/packages/terminal/ios/Plugin/StripeTerminalPlugin.swift
+++ b/packages/terminal/ios/Plugin/StripeTerminalPlugin.swift
@@ -49,12 +49,12 @@ public class StripeTerminalPlugin: CAPPlugin {
         self.implementation.disconnectReader(call)
     }
 
-    @objc func collect(_ call: CAPPluginCall) {
-        self.implementation.collect(call)
+    @objc func collectPaymentMethod(_ call: CAPPluginCall) {
+        self.implementation.collectPaymentMethod(call)
     }
 
-    @objc func cancelCollect(_ call: CAPPluginCall) {
-        self.implementation.cancelCollect(call)
+    @objc func cancelCollectPaymentMethod(_ call: CAPPluginCall) {
+        self.implementation.cancelCollectPaymentMethod(call)
     }
 
     @objc func confirmPaymentIntent(_ call: CAPPluginCall) {

--- a/packages/terminal/ios/Podfile
+++ b/packages/terminal/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'StripeTerminal', '~> 3.3.1'
+  pod 'StripeTerminal', '~> 3.4.0'
 end
 
 target 'Plugin' do

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/stripe-terminal",
-  "version": "5.5.0-beta.0",
+  "version": "5.5.0-beta.1",
   "description": "Stripe SDK bindings for Capacitor Applications",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/stripe-terminal",
-  "version": "5.5.0-beta.1",
+  "version": "5.5.0-beta.2",
   "description": "Stripe SDK bindings for Capacitor Applications",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/packages/terminal/src/definitions.ts
+++ b/packages/terminal/src/definitions.ts
@@ -67,4 +67,20 @@ export interface StripeTerminalPlugin {
     eventName: TerminalEventsEnum.Failed,
     listenerFunc: () => void,
   ): PluginListenerHandle;
+
+  /**
+   * This method has been deprecated and replaced by the `collectPaymentMethod`.
+   * Similarly, note that TerminalEvents.Completed is now obsolete.
+   * And, method `confirmPaymentIntent` added to be executed after `collectPaymentMethod` is executed.
+   *
+   * @deprecated
+   */
+  collect(options: { paymentIntent: string }): Promise<void>;
+
+  /**
+   * This method has been deprecated and replaced by the `cancelCollectPaymentMethod`.
+   *
+   * @deprecated
+   */
+  cancelCollect(options: { paymentIntent: string }): Promise<void>;
 }

--- a/packages/terminal/src/definitions.ts
+++ b/packages/terminal/src/definitions.ts
@@ -32,8 +32,8 @@ export interface StripeTerminalPlugin {
   getConnectedReader(): Promise<{ reader: ReaderInterface | null }>;
   disconnectReader(): Promise<void>;
   cancelDiscoverReaders(): Promise<void>;
-  collect(options: { paymentIntent: string }): Promise<void>;
-  cancelCollect(): Promise<void>;
+  collectPaymentMethod(options: { paymentIntent: string }): Promise<void>;
+  cancelCollectPaymentMethod(): Promise<void>;
   confirmPaymentIntent(): Promise<void>;
   addListener(
     eventName: TerminalEventsEnum.Loaded,

--- a/packages/terminal/src/definitions.ts
+++ b/packages/terminal/src/definitions.ts
@@ -69,18 +69,20 @@ export interface StripeTerminalPlugin {
   ): PluginListenerHandle;
 
   /**
+   * @deprecated
    * This method has been deprecated and replaced by the `collectPaymentMethod`.
    * Similarly, note that TerminalEvents.Completed is now obsolete.
    * And, method `confirmPaymentIntent` added to be executed after `collectPaymentMethod` is executed.
    *
-   * @deprecated
+   * This is left as type string to avoid accidental use.
    */
-  collect(options: { paymentIntent: string }): Promise<void>;
+  collect: string;
 
   /**
+   * @deprecated
    * This method has been deprecated and replaced by the `cancelCollectPaymentMethod`.
    *
-   * @deprecated
+   * This is left as type string to avoid accidental use.
    */
-  cancelCollect(options: { paymentIntent: string }): Promise<void>;
+  cancelCollect: string;
 }

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -76,11 +76,6 @@ export class StripeTerminalWeb
     this.notifyListeners(TerminalEventsEnum.ConfirmedPaymentIntent, null);
   }
 
-  async collect(options: { paymentIntent: string }): Promise<void> {
-    console.log('collect', options);
-  }
-
-  async cancelCollect(): Promise<void> {
-    console.log('cancelCollectPaymentMethod');
-  }
+  collect = 'deprecated';
+  cancelCollect = 'deprecated';
 }

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -59,7 +59,9 @@ export class StripeTerminalWeb
     this.notifyListeners(TerminalEventsEnum.DisconnectedReader, null);
   }
 
-  async collectPaymentMethod(options: { paymentIntent: string }): Promise<void> {
+  async collectPaymentMethod(options: {
+    paymentIntent: string;
+  }): Promise<void> {
     console.log('collectPaymentMethod', options);
     this.notifyListeners(TerminalEventsEnum.CollectedPaymentIntent, null);
   }

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -60,17 +60,25 @@ export class StripeTerminalWeb
   }
 
   async collectPaymentMethod(options: { paymentIntent: string }): Promise<void> {
-    console.log('collect', options);
+    console.log('collectPaymentMethod', options);
     this.notifyListeners(TerminalEventsEnum.CollectedPaymentIntent, null);
   }
 
   async cancelCollectPaymentMethod(): Promise<void> {
-    console.log('cancelCollect');
+    console.log('cancelCollectPaymentMethod');
     this.notifyListeners(TerminalEventsEnum.Canceled, null);
   }
 
   async confirmPaymentIntent(): Promise<void> {
     console.log('confirmPaymentIntent');
     this.notifyListeners(TerminalEventsEnum.ConfirmedPaymentIntent, null);
+  }
+
+  async collect(options: { paymentIntent: string }): Promise<void> {
+    console.log('collect', options);
+  }
+
+  async cancelCollect(): Promise<void> {
+    console.log('cancelCollectPaymentMethod');
   }
 }

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -59,12 +59,12 @@ export class StripeTerminalWeb
     this.notifyListeners(TerminalEventsEnum.DisconnectedReader, null);
   }
 
-  async collect(options: { paymentIntent: string }): Promise<void> {
+  async collectPaymentMethod(options: { paymentIntent: string }): Promise<void> {
     console.log('collect', options);
     this.notifyListeners(TerminalEventsEnum.CollectedPaymentIntent, null);
   }
 
-  async cancelCollect(): Promise<void> {
+  async cancelCollectPaymentMethod(): Promise<void> {
     console.log('cancelCollect');
     this.notifyListeners(TerminalEventsEnum.Canceled, null);
   }


### PR DESCRIPTION
related: https://github.com/capacitor-community/stripe/pull/342

- [x] add method `confirmPaymentIntent`
- [x] add listener `TerminalEventsEnum.ConfirmedPaymentIntent` and `TerminalEventsEnum.CollectedPaymentIntent`
- [x] remove listener `TerminalEventsEnum.Completed`

---

- [x] method `collect` to `collectPaymentMethod`
- [x] method `cancelCollect` to `cancelCollectPaymentMethod`
- [x] add method `collect` and `cancelCollect` to be deprecated tag.
- [x] sdk version to be 3.4.+  
- [x] change grant `ACCESS_FINE_LOCATION` process at android. complete the request at method `Initialize`.

---

- [x] support Bluetooth
- [x] support USB(Android only)

minSdk require 30: https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md?fbclid=IwAR1xPmIwpEub42qXqihB2szcU_pstuLxnUcCgV8v8LtuEQqtyiYkfYa7Ql0#tap-to-pay-localmobile-1