### PR TITLE
feat(payment): add google_pay_existing_payment_method_required to Manifest at Google Pay

### DIFF
--- a/demo/angular/android/app/src/main/AndroidManifest.xml
+++ b/demo/angular/android/app/src/main/AndroidManifest.xml
@@ -64,6 +64,10 @@
           android:name="com.getcapacitor.community.stripe.google_pay_is_testing"
           android:value="@bool/google_pay_is_testing"/>
 
+        <meta-data
+          android:name="com.getcapacitor.community.stripe.google_pay_existing_payment_method_required"
+          android:value="@bool/google_pay_existing_payment_method_required"/>
+
 <!--      <meta-data-->
 <!--        android:name="com.getcapacitor.community.stripe.stripe_account"-->
 <!--        android:value="@string/stripe_account"/>-->

--- a/demo/angular/android/app/src/main/res/values/strings.xml
+++ b/demo/angular/android/app/src/main/res/values/strings.xml
@@ -10,5 +10,6 @@
     <string name="country_code">US</string>
     <string name="merchant_display_name">Widget Store</string>
     <bool name="google_pay_is_testing">true</bool>
+    <bool name="google_pay_existing_payment_method_required">false</bool>
   <!--    <string name="stripe_account"></string>-->
 </resources>

--- a/demo/react/android/app/src/main/AndroidManifest.xml
+++ b/demo/react/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,10 @@
           android:name="com.getcapacitor.community.stripe.google_pay_is_testing"
           android:value="@bool/google_pay_is_testing"/>
 
+        <meta-data
+            android:name="com.getcapacitor.community.stripe.google_pay_existing_payment_method_required"
+            android:value="@bool/google_pay_existing_payment_method_required"/>
+
 <!--      <meta-data-->
 <!--        android:name="com.getcapacitor.community.stripe.stripe_account"-->
 <!--        android:value="@string/stripe_account"/>-->

--- a/demo/react/android/app/src/main/res/values/strings.xml
+++ b/demo/react/android/app/src/main/res/values/strings.xml
@@ -10,5 +10,6 @@
     <string name="country_code">US</string>
     <string name="merchant_display_name">Widget Store</string>
     <bool name="google_pay_is_testing">true</bool>
+    <bool name="google_pay_existing_payment_method_required">false</bool>
   <!--    <string name="stripe_account"></string>-->
 </resources>

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -79,7 +79,7 @@ public class StripePlugin extends Plugin {
                                 : GooglePayLauncher.BillingAddressConfig.Format.Min,
                             metaData.phoneNumberRequired
                         ),
-                            false
+                            metaData.existingPaymentMethodRequired
                     ),
                     (boolean isReady) -> this.googlePayExecutor.isAvailable = isReady,
                     (@NotNull GooglePayLauncher.Result result) ->

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.java
@@ -78,7 +78,8 @@ public class StripePlugin extends Plugin {
                                 ? GooglePayLauncher.BillingAddressConfig.Format.Full
                                 : GooglePayLauncher.BillingAddressConfig.Format.Min,
                             metaData.phoneNumberRequired
-                        )
+                        ),
+                            false
                     ),
                     (boolean isReady) -> this.googlePayExecutor.isAvailable = isReady,
                     (@NotNull GooglePayLauncher.Result result) ->

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/helper/MetaData.java
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/helper/MetaData.java
@@ -21,6 +21,8 @@ public class MetaData {
     public String billingAddressFormat;
     public GooglePayEnvironment googlePayEnvironment;
 
+    public Boolean existingPaymentMethodRequired;
+
     public boolean enableIdentifier;
 
     public MetaData(Supplier<Context> contextSupplier) {
@@ -40,6 +42,9 @@ public class MetaData {
             phoneNumberRequired = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.phone_number_required");
             billingAddressRequired = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.billing_address_required");
             billingAddressFormat = appInfo.metaData.getString("com.getcapacitor.community.stripe.billing_address_format");
+            existingPaymentMethodRequired = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.google_pay_existing_payment_method_required");
+
+            // @deprecated. will remove at v6.0.0
             enableIdentifier = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.enableIdentifier");
 
             boolean isTest = appInfo.metaData.getBoolean("com.getcapacitor.community.stripe.google_pay_is_testing");

--- a/packages/payment/package.json
+++ b/packages/payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/stripe",
-  "version": "5.5.0",
+  "version": "5.5.1-beta.0",
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
Related: https://github.com/capacitor-community/stripe/issues/329

- [x] existingPaymentMethodRequired can change.

```
If true, Google Pay is considered ready if the customer's Google Pay wallet has existing payment methods.
Default to true.
```

AndroidManifest.xml:

```diff
+        <meta-data
+            android:name="com.getcapacitor.community.stripe.google_pay_existing_payment_method_required"
+            android:value="@bool/google_pay_existing_payment_method_required"/>
```

string.xml

```diff
<bool name="google_pay_existing_payment_method_required">false</bool>
```