### PR TITLE
ios: fix: initial error value for apple pay

### DIFF
--- a/packages/payment/ios/Sources/StripePlugin/ApplePay/ApplePayExecutor.swift
+++ b/packages/payment/ios/Sources/StripePlugin/ApplePay/ApplePayExecutor.swift
@@ -155,7 +155,7 @@ extension ApplePayExecutor {
 
     func applePayContext(_ context: STPApplePayContext, didCreatePaymentMethod paymentMethod: StripeAPI.PaymentMethod, paymentInformation: PKPayment, completion: @escaping STPIntentClientSecretCompletionBlock) {
         let clientSecret = self.appleClientSecret
-        let error = "" // Call the completion block with the client secret or an error
+        let error: String? = nil // Call the completion block with the client secret or an error
         completion(clientSecret, error as? Error)
         let jsonArray = self.transformPKContactToJSON(contact: paymentInformation.shippingContact)
         self.plugin?.notifyListeners(ApplePayEvents.DidCreatePaymentMethod.rawValue, data: ["contact": jsonArray])


### PR DESCRIPTION
I made a correction in the STPApplePayContext.swift due to the guard statement being triggered by nil values.

Here is the relevant:
https://github.com/stripe/stripe-ios/blob/6a12711bfffae39034608b7fa4ad36cf90cdbe59/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift#L556