### PR TITLE
fix(android): metadata could not be loaded because context was not ready yet

### DIFF
--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.kt
@@ -29,7 +29,7 @@ class StripePlugin : Plugin() {
 
     private val identityVerificationCallbackId: String? = null
 
-    private var metaData: MetaData = MetaData { this.context }
+    private lateinit var metaData: MetaData;
 
     private val paymentSheetExecutor = PaymentSheetExecutor(
         { this.context },
@@ -53,6 +53,7 @@ class StripePlugin : Plugin() {
     )
 
     override fun load() {
+        this.metaData = MetaData { this.context };
         if (metaData.enableGooglePay) {
             this.publishableKey = metaData.publishableKey
 


### PR DESCRIPTION
The commit f1ddf70 changed the way as `metaData` initializes, but `this.context` is not ready to be used until `load()` is called, which MetaData always fails when initializing