### PR TITLE
feat(terminal): Implemented handoff connection type

### DIFF
--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -83,6 +83,10 @@ And add next block to `android/app/build.gradle`.
 + apply plugin: 'kotlin-android'
 ```
 
+If you are developing apps for Stripe Android devices (e.g. Stripe Reader S700), follow the Stripe's documentation for the client-side setup.
+- [Stripe - Android configure your app](https://docs.stripe.com/terminal/features/apps-on-devices/build?terminal-sdk-platform=android&lang-android=java#setup-app)
+
+
 ## Usage
 
 ### Simple collect payment
@@ -1048,6 +1052,7 @@ addListener(eventName: TerminalEventsEnum.ReaderReconnectFailed, listenerFunc: (
 | **`Bluetooth`** | <code>'bluetooth'</code>  |
 | **`Usb`**       | <code>'usb'</code>        |
 | **`TapToPay`**  | <code>'tap-to-pay'</code> |
+| **`HandOff`**   | <code>'hand-off'</code>   |
 
 
 #### SimulateReaderUpdate

--- a/packages/terminal/android/build.gradle
+++ b/packages/terminal/android/build.gradle
@@ -8,6 +8,7 @@ ext {
     volleyVersion = project.hasProperty('volleyVersion') ? rootProject.ext.volleyVersion : '1.2.1'
     stripeterminalTapToPayVersion = project.hasProperty('stripeterminalTapToPayVersion') ? rootProject.ext.stripeterminalTapToPayVersion : '4.1.0'
     stripeterminalCoreVersion = project.hasProperty('stripeterminalCoreVersion') ? rootProject.ext.stripeterminalCoreVersion : '4.1.0'
+    stripeterminalHandoffClientVersion = project.hasProperty('stripeterminalHandoffClientVersion') ? rootProject.ext.stripeterminalHandoffClientVersion : '4.1.0'
 }
 
 buildscript {
@@ -71,6 +72,7 @@ dependencies {
 
     implementation "com.stripe:stripeterminal-core:$stripeterminalCoreVersion"
     implementation "com.stripe:stripeterminal-taptopay:$stripeterminalTapToPayVersion"
+    implementation "com.stripe:stripeterminal-handoffclient:$stripeterminalHandoffClientVersion"
     implementation "com.android.volley:volley:$volleyVersion"
     implementation "com.google.android.gms:play-services-wallet:$playServicesWalletVersion"
 }

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/TerminalConnectTypes.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/TerminalConnectTypes.kt
@@ -6,4 +6,5 @@ enum class TerminalConnectTypes(val webEventName: String) {
     Bluetooth("bluetooth"),
     Usb("usb"),
     TapToPay("tap-to-pay"),
+    HandOff("hand-off"),
 }

--- a/packages/terminal/src/stripe.enum.ts
+++ b/packages/terminal/src/stripe.enum.ts
@@ -4,6 +4,7 @@ export enum TerminalConnectTypes {
   Bluetooth = 'bluetooth',
   Usb = 'usb',
   TapToPay = 'tap-to-pay',
+  HandOff = 'hand-off',
 }
 
 /**


### PR DESCRIPTION
PR for https://github.com/capacitor-community/stripe/issues/421

### Android Changes 
- Added new type `hand-off` in the **TerminalConnectTypes**
- Created a function to discover and connect to a reader using the `HandoffConnectionConfiguration`

### iOS Changes
- None since hand off configuration is only for Stripe Android devices

@rdlabo