### PR TITLE
fix(payment): BillingDetailsCollectionConfiguration: AddressCollectionMode: never

### DIFF
--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -35,7 +35,7 @@ export interface CreatePaymentFlowOption extends BasePaymentOption {
 /**
  * Billing details collection options.
  */
-export type AddressCollectionMode = 'automatic' | 'full';
+export type AddressCollectionMode = 'automatic' | 'full' | 'never';
 
 /**
  * Billing details collection options.


### PR DESCRIPTION
Allow AddressCollectionMode: never in BillingDetailsCollectionConfiguration for BasePaymentOption.
This aligns with the SDKs