### PR TITLE
#440 Update README.md to increase Stripe SDK verison for Stripe Terminal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ To use the latest Stripe Android, you need to version these up. To use the lates
 +   identityVersion = '21.3.+'
 
     // If you use @capacitor-community/stripe-terminal:
-+   stripeterminalCoreVersion = '4.1.0'
-+   stripeterminalTapToPayVersion = '4.1.0'
++   stripeterminalCoreVersion = '4.5.0'
++   stripeterminalTapToPayVersion = '4.5.0'
   }
 ```
 


### PR DESCRIPTION
Issue identified in #440 which requires latest versions of stripe sdk. Updating the README to reflect this.