### PR TITLE
refactor(ios): remove unused code

### DIFF
--- a/packages/payment/ios/Sources/StripePlugin/PaymentFlow/PaymentFlowExecutor.swift
+++ b/packages/payment/ios/Sources/StripePlugin/PaymentFlow/PaymentFlowExecutor.swift
@@ -40,13 +40,11 @@ class PaymentFlowExecutor: NSObject {
             configuration.returnURL = returnURL
         }
 
-        if #available(iOS 13.0, *) {
-            let style = call.getString("style") ?? ""
-            if style == "alwaysLight" {
-                configuration.style = .alwaysLight
-            } else if style == "alwaysDark" {
-                configuration.style = .alwaysDark
-            }
+        let style = call.getString("style") ?? ""
+        if style == "alwaysLight" {
+            configuration.style = .alwaysLight
+        } else if style == "alwaysDark" {
+            configuration.style = .alwaysDark
         }
 
         let applePayMerchantId = call.getString("applePayMerchantId") ?? ""

--- a/packages/payment/ios/Sources/StripePlugin/PaymentSheet/PaymentSheetExecutor.swift
+++ b/packages/payment/ios/Sources/StripePlugin/PaymentSheet/PaymentSheetExecutor.swift
@@ -40,13 +40,11 @@ class PaymentSheetExecutor: NSObject {
             configuration.returnURL = returnURL
         }
 
-        if #available(iOS 13.0, *) {
-            let style = call.getString("style") ?? ""
-            if style == "alwaysLight" {
-                configuration.style = .alwaysLight
-            } else if style == "alwaysDark" {
-                configuration.style = .alwaysDark
-            }
+        let style = call.getString("style") ?? ""
+        if style == "alwaysLight" {
+            configuration.style = .alwaysLight
+        } else if style == "alwaysDark" {
+            configuration.style = .alwaysDark
         }
 
         let applePayMerchantId = call.getString("applePayMerchantId") ?? ""


### PR DESCRIPTION
The plugin supports iOS 14+, remove the iOS 13 checks since it's always true.