### PR TITLE
feat(identity): remove deprecated event

### DIFF
--- a/demo/angular/src/app/demo/demo.page.ts
+++ b/demo/angular/src/app/demo/demo.page.ts
@@ -48,9 +48,6 @@ export class DemoPage implements OnInit {
   isApplePayAvailable = false;
   isGooglePayAvailable = false;
 
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
-
   constructor() {}
 
   async ngOnInit() {

--- a/demo/angular/src/app/flow/flow.page.ts
+++ b/demo/angular/src/app/flow/flow.page.ts
@@ -106,9 +106,6 @@ export class FlowPage {
   public eventItems: ITestItems[] = [];
   private readonly listenerHandlers: PluginListenerHandle[] = [];
 
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
-
   constructor() {
     addIcons({ playOutline, notificationsCircleOutline, checkmarkCircle });
   }

--- a/demo/angular/src/app/identity/identity.page.ts
+++ b/demo/angular/src/app/identity/identity.page.ts
@@ -43,7 +43,6 @@ const happyPathItems: ITestItems[] = [
   {
     type: 'method',
     name: 'presentIdentityVerificationSheet',
-    expect: [IdentityVerificationSheetEventsEnum.Completed],
   },
   {
     type: 'event',
@@ -72,7 +71,6 @@ const cancelPathItems: ITestItems[] = [
   {
     type: 'method',
     name: 'presentIdentityVerificationSheet',
-    expect: [IdentityVerificationSheetEventsEnum.Canceled],
   },
   {
     type: 'event',
@@ -107,9 +105,6 @@ export class IdentityPage {
 
   public eventItems: ITestItems[] = [];
   private readonly listenerHandlers: PluginListenerHandle[] = [];
-
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
 
   constructor() {
     addIcons({ playOutline, notificationsCircleOutline, checkmarkCircle });
@@ -172,12 +167,11 @@ export class IdentityPage {
         ),
       );
 
-    await StripeIdentity.present().then((data) => {
+    await StripeIdentity.present().then(() => {
       return this.helper.updateItem(
         this.eventItems,
         'presentIdentityVerificationSheet',
-        undefined,
-        data.identityVerificationResult,
+        true,
       );
     });
 

--- a/demo/angular/src/app/shared/helper.service.ts
+++ b/demo/angular/src/app/shared/helper.service.ts
@@ -7,9 +7,6 @@ import { ITestItems } from './interfaces';
 export class HelperService {
   private zone = inject(NgZone);
 
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
-
   constructor() {}
 
   /**

--- a/demo/angular/src/app/sheet/sheet.page.ts
+++ b/demo/angular/src/app/sheet/sheet.page.ts
@@ -95,9 +95,6 @@ export class SheetPage {
   public eventItems: ITestItems[] = [];
   private readonly listenerHandlers: PluginListenerHandle[] = [];
 
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
-
   constructor() {
     addIcons({ playOutline, notificationsCircleOutline, checkmarkCircle });
   }

--- a/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentity.kt
+++ b/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentity.kt
@@ -68,49 +68,25 @@ class StripeIdentity(
         }
     }
 
-    fun onVerificationCompleted(bridge: Bridge, callbackId: String?) {
+    fun onVerificationCompleted(bridge: Bridge) {
         notifyListeners(IdentityVerificationSheetEvent.VerificationResult.webEventName,
             JSObject().put(
                 "result",
                 IdentityVerificationSheetEvent.Completed.webEventName
             )
         )
-
-        val call = bridge.getSavedCall(callbackId)
-        notifyListeners(IdentityVerificationSheetEvent.Completed.webEventName, emptyObject)
-        if (call !== null) {
-            call.resolve(
-                JSObject().put(
-                    "identityVerificationResult",
-                    IdentityVerificationSheetEvent.Completed.webEventName
-                )
-            )
-            bridge.releaseCall(callbackId)
-        }
     }
 
-    fun onVerificationCancelled(bridge: Bridge, callbackId: String?) {
+    fun onVerificationCancelled(bridge: Bridge) {
         notifyListeners(IdentityVerificationSheetEvent.VerificationResult.webEventName,
             JSObject().put(
                 "result",
                 IdentityVerificationSheetEvent.Canceled.webEventName
             )
         )
-
-        val call = bridge.getSavedCall(callbackId)
-        notifyListeners(IdentityVerificationSheetEvent.Canceled.webEventName, emptyObject)
-        if (call !== null) {
-            call.resolve(
-                JSObject().put(
-                    "identityVerificationResult",
-                    IdentityVerificationSheetEvent.Canceled.webEventName
-                )
-            )
-            bridge.releaseCall(callbackId)
-        }
     }
 
-    fun onVerificationFailed(bridge: Bridge, errorMessage: String?, callbackId: String?) {
+    fun onVerificationFailed(bridge: Bridge, errorMessage: String?) {
         notifyListeners(IdentityVerificationSheetEvent.VerificationResult.webEventName,
             JSObject()
                 .put(
@@ -122,17 +98,5 @@ class StripeIdentity(
                     JSObject().put("message", errorMessage)
                 )
         )
-
-        val call = bridge.getSavedCall(callbackId)
-        notifyListeners(IdentityVerificationSheetEvent.Failed.webEventName, emptyObject)
-        if (call !== null) {
-            call.resolve(
-                JSObject().put(
-                    "identityVerificationResult",
-                    IdentityVerificationSheetEvent.Failed.webEventName
-                )
-            )
-            bridge.releaseCall(callbackId)
-        }
     }
 }

--- a/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentityPlugin.kt
+++ b/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentityPlugin.kt
@@ -13,8 +13,6 @@ import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowRes
 
 @CapacitorPlugin(name = "StripeIdentity")
 class StripeIdentityPlugin : Plugin() {
-    private var identityVerificationCallbackId: String? = null
-
     private val implementation = StripeIdentity(
         { this.context },
         { this.activity },
@@ -40,16 +38,16 @@ class StripeIdentityPlugin : Plugin() {
             if (verificationFlowResult is VerificationFlowResult.Completed) {
                 // The user has completed uploading their documents.
                 // Let them know that the verification is processing.
-                implementation.onVerificationCompleted(bridge, identityVerificationCallbackId)
+                implementation.onVerificationCompleted(bridge)
             } else if (verificationFlowResult is VerificationFlowResult.Canceled) {
                 // The user did not complete uploading their documents.
                 // You should allow them to try again.
-                implementation.onVerificationCancelled(bridge, identityVerificationCallbackId)
+                implementation.onVerificationCancelled(bridge)
             } else if (verificationFlowResult is VerificationFlowResult.Failed) {
                 // If the flow fails, you should display the localized error
                 // message to your user using throwable.getLocalizedMessage()
                 val errorMessage = verificationFlowResult.throwable.localizedMessage;
-                implementation.onVerificationFailed(bridge, errorMessage, identityVerificationCallbackId)
+                implementation.onVerificationFailed(bridge, errorMessage)
             }
         }
     }
@@ -66,8 +64,6 @@ class StripeIdentityPlugin : Plugin() {
 
     @PluginMethod
     fun present(call: PluginCall) {
-        identityVerificationCallbackId = call.callbackId
-
         call.setKeepAlive(true);
         bridge.saveCall(call)
 

--- a/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentityPlugin.kt
+++ b/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentityPlugin.kt
@@ -64,9 +64,6 @@ class StripeIdentityPlugin : Plugin() {
 
     @PluginMethod
     fun present(call: PluginCall) {
-        call.setKeepAlive(true);
-        bridge.saveCall(call)
-
         implementation.present(call)
     }
 }

--- a/packages/identity/ios/Sources/StripeIdentityPlugin/StripeIdentity.swift
+++ b/packages/identity/ios/Sources/StripeIdentityPlugin/StripeIdentity.swift
@@ -57,9 +57,7 @@ import StripeIdentity
                         self.plugin?.notifyListeners(IdentityVerificationSheetEvents.VerificationResult.rawValue, data: [
                             "result": IdentityVerificationSheetEvents.Completed.rawValue
                         ])
-                        
-                        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Completed.rawValue, data: [:])
-                        call.resolve(["identityVerificationResult": IdentityVerificationSheetEvents.Completed.rawValue])
+                        call.resolve([:])
                     case .flowCanceled:
                         // The user did not complete uploading their documents.
                         // You should allow them to try again.
@@ -67,9 +65,7 @@ import StripeIdentity
                         self.plugin?.notifyListeners(IdentityVerificationSheetEvents.VerificationResult.rawValue, data: [
                             "result": IdentityVerificationSheetEvents.Canceled.rawValue
                         ])
-                        
-                        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Canceled.rawValue, data: [:])
-                        call.resolve(["identityVerificationResult": IdentityVerificationSheetEvents.Canceled.rawValue])
+                        call.resolve([:])
                     case .flowFailed(let error):
                         // If the flow fails, you should display the localized error
                         // message to your user using error.localizedDescription
@@ -81,9 +77,7 @@ import StripeIdentity
                                 "message": error.localizedDescription
                             ]
                         ])
-                        
-                        self.plugin?.notifyListeners(IdentityVerificationSheetEvents.Failed.rawValue, data: ["message": error.localizedDescription])
-                        call.resolve(["identityVerificationResult": IdentityVerificationSheetEvents.Failed.rawValue])
+                        call.resolve([:])
                     }
                 })
             }

--- a/packages/identity/src/definitions.ts
+++ b/packages/identity/src/definitions.ts
@@ -9,21 +9,6 @@ export interface StripeIdentityError {
   message: string;
 }
 
-/**
- * @deprecated
- * `identityVerificationResult` is deprecated and will be removed in the next major version (v8).
- *
- *
- * This property relies on a PluginCall that cannot be persisted reliably across Android lifecycle events.
- * Due to limitations in the Capacitor plugin system, the saved call is lost when the activity is destroyed
- * (e.g., due to backgrounding, rotation, or process death).
- * To avoid inconsistent behavior and potential crashes, please migrate to a stateless design where any necessary data
- * is persisted explicitly and reprocessed on app resume or reload.
- */
-export interface deprecatedIdentityVerificationResult {
-  identityVerificationResult: IdentityVerificationSheetResultInterface;
-}
-
 export interface IdentityVerificationResult {
   result: IdentityVerificationSheetResultInterface;
   error?: StripeIdentityError;
@@ -32,7 +17,7 @@ export interface IdentityVerificationResult {
 export interface StripeIdentityPlugin {
   initialize(options: InitializeIdentityVerificationSheetOption): Promise<void>;
   create(options: CreateIdentityVerificationSheetOption): Promise<void>;
-  present(): Promise<deprecatedIdentityVerificationResult>;
+  present(): Promise<void>;
 
   addListener(
     eventName: IdentityVerificationSheetEventsEnum.Loaded,
@@ -47,44 +32,5 @@ export interface StripeIdentityPlugin {
   addListener(
     eventName: IdentityVerificationSheetEventsEnum.VerificationResult,
     listenerFunc: (result: IdentityVerificationResult) => void,
-  ): Promise<PluginListenerHandle>;
-
-  /**
-   * @deprecated
-   * Listening to verification results via `present()` is deprecated.
-   *
-   * Please use `addListener(IdentityVerificationSheetEventsEnum.VerificationResult, listener)` instead.
-   * This new event-based approach provides better reliability across app lifecycle events such as backgrounding,
-   * rotation, and process restarts.
-   */
-  addListener(
-    eventName: IdentityVerificationSheetEventsEnum.Completed,
-    listenerFunc: () => void,
-  ): Promise<PluginListenerHandle>;
-
-  /**
-   * @deprecated
-   * Listening to verification results via `present()` is deprecated.
-   *
-   * Please use `addListener(IdentityVerificationSheetEventsEnum.VerificationResult, listener)` instead.
-   * This new event-based approach provides better reliability across app lifecycle events such as backgrounding,
-   * rotation, and process restarts.
-   */
-  addListener(
-    eventName: IdentityVerificationSheetEventsEnum.Canceled,
-    listenerFunc: () => void,
-  ): Promise<PluginListenerHandle>;
-
-  /**
-   * @deprecated
-   * Listening to verification results via `present()` is deprecated.
-   *
-   * Please use `addListener(IdentityVerificationSheetEventsEnum.VerificationResult, listener)` instead.
-   * This new event-based approach provides better reliability across app lifecycle events such as backgrounding,
-   * rotation, and process restarts.
-   */
-  addListener(
-    eventName: IdentityVerificationSheetEventsEnum.Failed,
-    listenerFunc: (info: StripeIdentityError) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/packages/identity/src/web.ts
+++ b/packages/identity/src/web.ts
@@ -2,7 +2,7 @@ import { WebPlugin } from '@capacitor/core';
 import type { Stripe } from '@stripe/stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 
-import type { deprecatedIdentityVerificationResult, StripeIdentityPlugin } from './definitions';
+import type { StripeIdentityPlugin } from './definitions';
 import { IdentityVerificationSheetEventsEnum } from './definitions';
 
 export interface InitializeIdentityVerificationSheetOption {
@@ -29,7 +29,7 @@ export class StripeIdentityWeb extends WebPlugin implements StripeIdentityPlugin
     this.clientSecret = options.clientSecret;
     this.notifyListeners(IdentityVerificationSheetEventsEnum.Loaded, null);
   }
-  async present(): Promise<deprecatedIdentityVerificationResult> {
+  async present(): Promise<void> {
     if (!this.stripe) {
       throw new Error('Stripe is not initialized.');
     }
@@ -38,36 +38,21 @@ export class StripeIdentityWeb extends WebPlugin implements StripeIdentityPlugin
     }
     const { error } = await this.stripe.verifyIdentity(this.clientSecret);
     if (error) {
-      const { code, message } = error;
+      const { code } = error;
       if (code === 'session_cancelled') {
-        this.notifyListeners(IdentityVerificationSheetEventsEnum.Canceled, {
-          message,
-        });
-
         this.notifyListeners(IdentityVerificationSheetEventsEnum.VerificationResult, {
           result: IdentityVerificationSheetEventsEnum.Canceled,
         });
-        return {
-          identityVerificationResult: IdentityVerificationSheetEventsEnum.Canceled,
-        };
+        return;
       }
-      this.notifyListeners(IdentityVerificationSheetEventsEnum.Failed, error);
-
       this.notifyListeners(IdentityVerificationSheetEventsEnum.VerificationResult, {
         result: IdentityVerificationSheetEventsEnum.Failed,
         error,
       });
-      return {
-        identityVerificationResult: IdentityVerificationSheetEventsEnum.Failed,
-      };
+      return;
     }
-    this.notifyListeners(IdentityVerificationSheetEventsEnum.Completed, null);
-
     this.notifyListeners(IdentityVerificationSheetEventsEnum.VerificationResult, {
       result: IdentityVerificationSheetEventsEnum.Completed,
     });
-    return {
-      identityVerificationResult: IdentityVerificationSheetEventsEnum.Completed,
-    };
   }
 }


### PR DESCRIPTION
## ⚠️ Breaking Change

Deprecated Identity APIs have been **fully removed**.

### Removed
- Deprecated events: `Completed`, `Canceled`, `Failed`
- Deprecated return values and related types
- `present()` now always returns `void`

### Changed
- Verification results are now delivered **only** via the `VerificationResult` event
- Unified and simplified behavior across Web / iOS / Android

⚠️ **This is a breaking change.**  
Apps using deprecated events or relying on return values must migrate to `VerificationResult`.