### PR TITLE
feat(terminal): add setTapToPayUxConfiguration for Android

### DIFF
--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -222,6 +222,7 @@ await StripeTerminal.setSimulatorConfiguration({ update: SimulateReaderUpdate.Up
 * [`clearReaderDisplay()`](#clearreaderdisplay)
 * [`rebootReader()`](#rebootreader)
 * [`cancelReaderReconnection()`](#cancelreaderreconnection)
+* [`setTapToPayUxConfiguration(...)`](#settaptopayuxconfiguration)
 * [`addListener(TerminalEventsEnum.Loaded, ...)`](#addlistenerterminaleventsenumloaded-)
 * [`addListener(TerminalEventsEnum.RequestedConnectionToken, ...)`](#addlistenerterminaleventsenumrequestedconnectiontoken-)
 * [`addListener(TerminalEventsEnum.DiscoveredReaders, ...)`](#addlistenerterminaleventsenumdiscoveredreaders-)
@@ -437,6 +438,23 @@ rebootReader() => Promise<void>
 ```typescript
 cancelReaderReconnection() => Promise<void>
 ```
+
+--------------------
+
+
+### setTapToPayUxConfiguration(...)
+
+```typescript
+setTapToPayUxConfiguration(options: TapToPayUxConfiguration) => Promise<void>
+```
+
+Configure the Tap to Pay UX appearance (Android only).
+Call this after initialize() but before connectReader().
+Has no effect on iOS or web platforms.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#taptopayuxconfiguration">TapToPayUxConfiguration</a></code> |
 
 --------------------
 
@@ -922,6 +940,28 @@ addListener(eventName: TerminalEventsEnum.ReaderReconnectFailed, listenerFunc: (
 | **`bluetoothScanWaitTime`** | <code>number</code>                                                   | Only applies to Bluetooth scan discovery (iOS only). During discovery, readers are reported via DiscoveryDelegate.didUpdateDiscoveredReaders. This timeout controls how long to wait before resolving the `discoverReaders` method with the current list. If this setting is not specified or is set to 0, the initial scan results will be returned. |
 
 
+#### TapToPayUxConfiguration
+
+Configuration for the Tap to Pay UX (Android only).
+
+| Prop           | Type                                                                | Description                            |
+| -------------- | ------------------------------------------------------------------- | -------------------------------------- |
+| **`colors`**   | <code><a href="#taptopaycolorscheme">TapToPayColorScheme</a></code> | Color scheme for the Tap to Pay screen |
+| **`darkMode`** | <code><a href="#taptopaydarkmode">TapToPayDarkMode</a></code>       | Dark mode setting                      |
+| **`tapZone`**  | <code><a href="#taptopaytapzone">TapToPayTapZone</a></code>         | Tap zone position configuration        |
+
+
+#### TapToPayColorScheme
+
+Color scheme for the Tap to Pay screen.
+
+| Prop          | Type                                                    | Description                                                  |
+| ------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
+| **`primary`** | <code><a href="#taptopaycolor">TapToPayColor</a></code> | Primary color (tap zone indicator). Hex string or 'default'. |
+| **`success`** | <code><a href="#taptopaycolor">TapToPayColor</a></code> | Success state color. Hex string or 'default'.                |
+| **`error`**   | <code><a href="#taptopaycolor">TapToPayColor</a></code> | Error state color. Hex string or 'default'.                  |
+
+
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
@@ -960,6 +1000,22 @@ addListener(eventName: TerminalEventsEnum.ReaderReconnectFailed, listenerFunc: (
 #### CartLineItem
 
 <code>{ displayName: string; quantity: number; amount: number; }</code>
+
+
+#### TapToPayColor
+
+Color value for <a href="#taptopayuxconfiguration">TapToPayUxConfiguration</a>.
+Use 'default' to use Stripe's default color, or a hex string like '#965D35'.
+
+<code>'default' | string</code>
+
+
+#### TapToPayTapZone
+
+Tap zone position configuration.
+Controls where the tap indicator appears on screen.
+
+<code>{ type: 'default' } | { type: 'front'; xBias: number; yBias: number } | { type: 'behind'; xBias: number; yBias: number } | { type: 'above'; bias?: number } | { type: 'below'; bias?: number } | { type: 'left'; bias?: number } | { type: 'right'; bias?: number }</code>
 
 
 ### Enums
@@ -1080,6 +1136,15 @@ addListener(eventName: TerminalEventsEnum.ReaderReconnectFailed, listenerFunc: (
 | **`OfflinePinSCARetry`**              | <code>'OFFLINE_PIN_SCA_RETRY'</code>              |
 | **`OnlinePinCVM`**                    | <code>'ONLINE_PIN_CVM'</code>                     |
 | **`OnlinePinSCARetry`**               | <code>'ONLINE_PIN_SCA_RETRY'</code>               |
+
+
+#### TapToPayDarkMode
+
+| Members      | Value                 |
+| ------------ | --------------------- |
+| **`System`** | <code>'SYSTEM'</code> |
+| **`Dark`**   | <code>'DARK'</code>   |
+| **`Light`**  | <code>'LIGHT'</code>  |
 
 
 #### TerminalEventsEnum

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.os.Build
 import android.util.Log
 import androidx.core.app.ActivityCompat
@@ -49,6 +50,7 @@ import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
 import com.stripe.stripeterminal.external.models.SimulateReaderUpdate
 import com.stripe.stripeterminal.external.models.SimulatedCard
 import com.stripe.stripeterminal.external.models.SimulatorConfiguration
+import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripe.stripeterminal.log.LogLevel
 import org.json.JSONException
@@ -899,6 +901,73 @@ class StripeTerminal(
                     JSObject().put("reason", reason.toString())
                 )
             }
+        }
+    }
+
+    fun setTapToPayUxConfiguration(call: PluginCall) {
+        try {
+            val builder = TapToPayUxConfiguration.Builder()
+
+            // Parse colors
+            call.getObject("colors")?.let { colorsObj ->
+                val colorSchemeBuilder = TapToPayUxConfiguration.ColorScheme.Builder()
+                colorsObj.getString("primary")?.let { colorSchemeBuilder.primary(parseColor(it)) }
+                colorsObj.getString("success")?.let { colorSchemeBuilder.success(parseColor(it)) }
+                colorsObj.getString("error")?.let { colorSchemeBuilder.error(parseColor(it)) }
+                builder.colors(colorSchemeBuilder.build())
+            }
+
+            // Parse dark mode
+            call.getString("darkMode")?.let { darkModeStr ->
+                val darkMode = when (darkModeStr) {
+                    "DARK" -> TapToPayUxConfiguration.DarkMode.DARK
+                    "LIGHT" -> TapToPayUxConfiguration.DarkMode.LIGHT
+                    else -> TapToPayUxConfiguration.DarkMode.SYSTEM
+                }
+                builder.darkMode(darkMode)
+            }
+
+            // TODO: Tap zone support requires Stripe Terminal SDK v5+
+            // Uncomment when upgrading from v4.7 to v5+
+            // call.getObject("tapZone")?.let { tapZoneObj ->
+            //     val tapZone = when (tapZoneObj.getString("type")) {
+            //         "front" -> TapToPayUxConfiguration.TapZone.Front(
+            //             tapZoneObj.getDouble("xBias")?.toFloat() ?: 0.5f,
+            //             tapZoneObj.getDouble("yBias")?.toFloat() ?: 0.5f
+            //         )
+            //         "behind" -> TapToPayUxConfiguration.TapZone.Behind(
+            //             tapZoneObj.getDouble("xBias")?.toFloat() ?: 0.5f,
+            //             tapZoneObj.getDouble("yBias")?.toFloat() ?: 0.5f
+            //         )
+            //         "above" -> TapToPayUxConfiguration.TapZone.Above(
+            //             tapZoneObj.getDouble("bias")?.toFloat() ?: 0.5f
+            //         )
+            //         "below" -> TapToPayUxConfiguration.TapZone.Below(
+            //             tapZoneObj.getDouble("bias")?.toFloat() ?: 0.5f
+            //         )
+            //         "left" -> TapToPayUxConfiguration.TapZone.Left(
+            //             tapZoneObj.getDouble("bias")?.toFloat() ?: 0.5f
+            //         )
+            //         "right" -> TapToPayUxConfiguration.TapZone.Right(
+            //             tapZoneObj.getDouble("bias")?.toFloat() ?: 0.5f
+            //         )
+            //         else -> TapToPayUxConfiguration.TapZone.Default
+            //     }
+            //     builder.tapZone(tapZone)
+            // }
+
+            Terminal.getInstance().setTapToPayUxConfiguration(builder.build())
+            call.resolve()
+        } catch (ex: Exception) {
+            call.reject(ex.message)
+        }
+    }
+
+    private fun parseColor(colorStr: String): TapToPayUxConfiguration.Color {
+        return if (colorStr == "default") {
+            TapToPayUxConfiguration.Color.Default
+        } else {
+            TapToPayUxConfiguration.Color.Value(Color.parseColor(colorStr))
         }
     }
 

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
@@ -202,4 +202,9 @@ class StripeTerminalPlugin : Plugin() {
     fun cancelReaderReconnection(call: PluginCall) {
         implementation.cancelReaderReconnection(call)
     }
+
+    @PluginMethod
+    fun setTapToPayUxConfiguration(call: PluginCall) {
+        implementation.setTapToPayUxConfiguration(call)
+    }
 }

--- a/packages/terminal/src/definitions.ts
+++ b/packages/terminal/src/definitions.ts
@@ -91,6 +91,58 @@ export type Cart = {
   lineItems: CartLineItem[];
 };
 
+/**
+ * Color value for TapToPayUxConfiguration.
+ * Use 'default' to use Stripe's default color, or a hex string like '#965D35'.
+ */
+export type TapToPayColor = 'default' | string;
+
+/**
+ * Dark mode setting for Tap to Pay UX.
+ */
+export enum TapToPayDarkMode {
+  System = 'SYSTEM',
+  Dark = 'DARK',
+  Light = 'LIGHT',
+}
+
+/**
+ * Color scheme for the Tap to Pay screen.
+ */
+export interface TapToPayColorScheme {
+  /** Primary color (tap zone indicator). Hex string or 'default'. */
+  primary?: TapToPayColor;
+  /** Success state color. Hex string or 'default'. */
+  success?: TapToPayColor;
+  /** Error state color. Hex string or 'default'. */
+  error?: TapToPayColor;
+}
+
+/**
+ * Tap zone position configuration.
+ * Controls where the tap indicator appears on screen.
+ */
+export type TapToPayTapZone =
+  | { type: 'default' }
+  | { type: 'front'; xBias: number; yBias: number }
+  | { type: 'behind'; xBias: number; yBias: number }
+  | { type: 'above'; bias?: number }
+  | { type: 'below'; bias?: number }
+  | { type: 'left'; bias?: number }
+  | { type: 'right'; bias?: number };
+
+/**
+ * Configuration for the Tap to Pay UX (Android only).
+ */
+export interface TapToPayUxConfiguration {
+  /** Color scheme for the Tap to Pay screen */
+  colors?: TapToPayColorScheme;
+  /** Dark mode setting */
+  darkMode?: TapToPayDarkMode;
+  /** Tap zone position configuration */
+  tapZone?: TapToPayTapZone;
+}
+
 export interface DiscoverReadersOptions {
   type: TerminalConnectTypes;
   locationId?: string;
@@ -152,6 +204,13 @@ export interface StripeTerminalPlugin {
   clearReaderDisplay(): Promise<void>;
   rebootReader(): Promise<void>;
   cancelReaderReconnection(): Promise<void>;
+
+  /**
+   * Configure the Tap to Pay UX appearance (Android only).
+   * Call this after initialize() but before connectReader().
+   * Has no effect on iOS or web platforms.
+   */
+  setTapToPayUxConfiguration(options: TapToPayUxConfiguration): Promise<void>;
 
   addListener(eventName: TerminalEventsEnum.Loaded, listenerFunc: () => void): Promise<PluginListenerHandle>;
 

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -10,6 +10,7 @@ import type {
   SimulateReaderUpdate,
   SimulatedCardType,
   Cart,
+  TapToPayUxConfiguration,
 } from './definitions';
 import { TerminalEventsEnum } from './events.enum';
 import {
@@ -212,6 +213,10 @@ export class StripeTerminalWeb extends WebPlugin implements StripeTerminalPlugin
   }
   async cancelReaderReconnection(): Promise<void> {
     console.log('cancelReaderReconnection');
+  }
+
+  async setTapToPayUxConfiguration(_options: TapToPayUxConfiguration): Promise<void> {
+    console.log('setTapToPayUxConfiguration is only supported on Android');
   }
 
   collect = 'deprecated';


### PR DESCRIPTION
## Summary
Adds `setTapToPayUxConfiguration()` method to customize the Tap to Pay UI appearance on Android devices.

## Motivation
Stripe Terminal SDK 4.7+ exposes `TapToPayUxConfiguration` for branding customization during card collection. This PR surfaces that API to Capacitor applications.

## Changes
- **definitions.ts**: TypeScript types for colors, dark mode, tap zones
- **StripeTerminal.kt**: Android implementation with color parsing
- **StripeTerminalPlugin.kt**: Plugin method registration
- **web.ts**: Console log stub for web platform
- **README.md**: Auto-generated documentation

## API
```typescript
await StripeTerminal.setTapToPayUxConfiguration({
    colors: { primary: '#FF5733' },
    darkMode: TapToPayDarkMode.Light,
});
```

## Platform Support
| Platform | Status |
|----------|--------|
| Android | ✅ Full support |
| iOS | ⏭️ No-op (SDK limitation) |
| Web | ⏭️ Console log only |

## SDK Compatibility
- Colors + dark mode: SDK v4.7+
 - Tap zones: SDK v5+ (code prepared but commented)

## Testing
- Tested on Android 16 with Capacitor 8
- Verified color customization applies to tap-to-pay collection screen