### PR TITLE
feat(apple-pay): add updateApplePaySheet to update payment items on shipping contact selection

### DIFF
--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -24,6 +24,7 @@ Learn at [the official @capacitor-community/stripe documentation](https://stripe
 * [`isApplePayAvailable()`](#isapplepayavailable)
 * [`createApplePay(...)`](#createapplepay)
 * [`presentApplePay()`](#presentapplepay)
+* [`updateApplePaySheet(...)`](#updateapplepaysheet)
 * [`addListener(ApplePayEventsEnum.Loaded, ...)`](#addlistenerapplepayeventsenumloaded-)
 * [`addListener(ApplePayEventsEnum.FailedToLoad, ...)`](#addlistenerapplepayeventsenumfailedtoload-)
 * [`addListener(ApplePayEventsEnum.Completed, ...)`](#addlistenerapplepayeventsenumcompleted-)
@@ -122,6 +123,19 @@ presentApplePay() => Promise<{ paymentResult: ApplePayResultInterface; }>
 ```
 
 **Returns:** <code>Promise&lt;{ paymentResult: <a href="#applepayresultinterface">ApplePayResultInterface</a>; }&gt;</code>
+
+--------------------
+
+
+### updateApplePaySheet(...)
+
+```typescript
+updateApplePaySheet(options: { paymentSummaryItems: PaymentSummaryItem[]; }) => Promise<void>
+```
+
+| Param         | Type                                                        |
+| ------------- | ----------------------------------------------------------- |
+| **`options`** | <code>{ paymentSummaryItems: PaymentSummaryItem[]; }</code> |
 
 --------------------
 
@@ -625,13 +639,21 @@ addListener(eventName: PaymentSheetEventsEnum.Failed, listenerFunc: (error: stri
 | Prop                                   | Type                                                                          |
 | -------------------------------------- | ----------------------------------------------------------------------------- |
 | **`paymentIntentClientSecret`**        | <code>string</code>                                                           |
-| **`paymentSummaryItems`**              | <code>{ label: string; amount: number; }[]</code>                             |
+| **`paymentSummaryItems`**              | <code>PaymentSummaryItem[]</code>                                             |
 | **`merchantIdentifier`**               | <code>string</code>                                                           |
 | **`countryCode`**                      | <code>string</code>                                                           |
 | **`currency`**                         | <code>string</code>                                                           |
 | **`requiredShippingContactFields`**    | <code>('postalAddress' \| 'phoneNumber' \| 'emailAddress' \| 'name')[]</code> |
 | **`allowedCountries`**                 | <code>string[]</code>                                                         |
 | **`allowedCountriesErrorDescription`** | <code>string</code>                                                           |
+
+
+#### PaymentSummaryItem
+
+| Prop         | Type                |
+| ------------ | ------------------- |
+| **`label`**  | <code>string</code> |
+| **`amount`** | <code>number</code> |
 
 
 #### PluginListenerHandle

--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -130,12 +130,12 @@ presentApplePay() => Promise<{ paymentResult: ApplePayResultInterface; }>
 ### updateApplePaySheet(...)
 
 ```typescript
-updateApplePaySheet(options: { paymentSummaryItems: PaymentSummaryItem[]; }) => Promise<void>
+updateApplePaySheet(options: { updateId: string; paymentSummaryItems: PaymentSummaryItem[]; }) => Promise<void>
 ```
 
-| Param         | Type                                                        |
-| ------------- | ----------------------------------------------------------- |
-| **`options`** | <code>{ paymentSummaryItems: PaymentSummaryItem[]; }</code> |
+| Param         | Type                                                                          |
+| ------------- | ----------------------------------------------------------------------------- |
+| **`options`** | <code>{ updateId: string; paymentSummaryItems: PaymentSummaryItem[]; }</code> |
 
 --------------------
 
@@ -239,13 +239,13 @@ addListener(eventName: ApplePayEventsEnum.DidSelectShippingContact, listenerFunc
 ### addListener(ApplePayEventsEnum.DidCreatePaymentMethod, ...)
 
 ```typescript
-addListener(eventName: ApplePayEventsEnum.DidCreatePaymentMethod, listenerFunc: (data: DidSelectShippingContact) => void) => Promise<PluginListenerHandle>
+addListener(eventName: ApplePayEventsEnum.DidCreatePaymentMethod, listenerFunc: (data: DidCreatePaymentMethod) => void) => Promise<PluginListenerHandle>
 ```
 
-| Param              | Type                                                                                             |
-| ------------------ | ------------------------------------------------------------------------------------------------ |
-| **`eventName`**    | <code><a href="#applepayeventsenum">ApplePayEventsEnum.DidCreatePaymentMethod</a></code>         |
-| **`listenerFunc`** | <code>(data: <a href="#didselectshippingcontact">DidSelectShippingContact</a>) =&gt; void</code> |
+| Param              | Type                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#applepayeventsenum">ApplePayEventsEnum.DidCreatePaymentMethod</a></code>     |
+| **`listenerFunc`** | <code>(data: <a href="#didcreatepaymentmethod">DidCreatePaymentMethod</a>) =&gt; void</code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
@@ -665,9 +665,10 @@ addListener(eventName: PaymentSheetEventsEnum.Failed, listenerFunc: (error: stri
 
 #### DidSelectShippingContact
 
-| Prop          | Type                                                        |
-| ------------- | ----------------------------------------------------------- |
-| **`contact`** | <code><a href="#shippingcontact">ShippingContact</a></code> |
+| Prop           | Type                                                        |
+| -------------- | ----------------------------------------------------------- |
+| **`contact`**  | <code><a href="#shippingcontact">ShippingContact</a></code> |
+| **`updateId`** | <code>string</code>                                         |
 
 
 #### ShippingContact
@@ -690,6 +691,13 @@ addListener(eventName: PaymentSheetEventsEnum.Failed, listenerFunc: (error: stri
 | **`isoCountryCode`**        | <code>string</code> | Apple Pay only |
 | **`subAdministrativeArea`** | <code>string</code> | Apple Pay only |
 | **`subLocality`**           | <code>string</code> | Apple Pay only |
+
+
+#### DidCreatePaymentMethod
+
+| Prop          | Type                                                        |
+| ------------- | ----------------------------------------------------------- |
+| **`contact`** | <code><a href="#shippingcontact">ShippingContact</a></code> |
 
 
 #### CreateGooglePayOption

--- a/packages/payment/ios/Sources/StripePlugin/ApplePay/ApplePayExecutor.swift
+++ b/packages/payment/ios/Sources/StripePlugin/ApplePay/ApplePayExecutor.swift
@@ -10,6 +10,8 @@ class ApplePayExecutor: NSObject, ApplePayContextDelegate {
     private var paymentRequest: PKPaymentRequest?
     private var allowedCountries: [String] = []
     private var allowedCountriesErrorDescription: String = ""
+    private var pendingShippingHandler: ((PKPaymentRequestShippingContactUpdate) -> Void)?
+    private var shippingHandlerWorkItem: DispatchWorkItem?
 
     func isApplePayAvailable(_ call: CAPPluginCall) {
         if !StripeAPI.deviceSupportsApplePay() {
@@ -135,21 +137,56 @@ extension ApplePayExecutor {
 
     // For security reasons, Apple does not return the full address until a successful payment has been made.
     func applePayContext(_ context: STPApplePayContext, didSelectShippingContact contact: PKContact, handler: @escaping (PKPaymentRequestShippingContactUpdate) -> Void) {
-        handler(PKPaymentRequestShippingContactUpdate.init(paymentSummaryItems: []))
-        let jsonArray = self.transformPKContactToJSON(contact: contact)
-        self.plugin?.notifyListeners(ApplePayEvents.DidSelectShippingContact.rawValue, data: ["contact": jsonArray])
-
-        // Check allowed countries
+        // Validate allowed countries first — respond immediately if invalid
         if !self.allowedCountries.isEmpty {
-            let addressIsoCountry = (contact.postalAddress?.isoCountryCode as? String ?? "").lowercased()
+            let addressIsoCountry = (contact.postalAddress?.isoCountryCode ?? "").lowercased()
             if !self.allowedCountries.contains(addressIsoCountry) {
-                handler(PKPaymentRequestShippingContactUpdate.init(
+                handler(PKPaymentRequestShippingContactUpdate(
                     errors: [PKPaymentRequest.paymentShippingAddressInvalidError(withKey: CNPostalAddressISOCountryCodeKey, localizedDescription: self.allowedCountriesErrorDescription)],
                     paymentSummaryItems: self.paymentRequest?.paymentSummaryItems ?? [],
                     shippingMethods: self.paymentRequest?.shippingMethods ?? []))
                 return
             }
         }
+
+        // Store handler so JS can call updateApplePaySheet with updated items
+        shippingHandlerWorkItem?.cancel()
+        pendingShippingHandler = handler
+
+        // Fallback: resolve with original items after 25s if JS does not respond
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self, let pendingHandler = self.pendingShippingHandler else { return }
+            self.pendingShippingHandler = nil
+            pendingHandler(PKPaymentRequestShippingContactUpdate(paymentSummaryItems: self.paymentRequest?.paymentSummaryItems ?? []))
+        }
+        shippingHandlerWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 25, execute: workItem)
+
+        let jsonArray = self.transformPKContactToJSON(contact: contact)
+        self.plugin?.notifyListeners(ApplePayEvents.DidSelectShippingContact.rawValue, data: ["contact": jsonArray])
+    }
+
+    func updateApplePaySheet(_ call: CAPPluginCall) {
+        shippingHandlerWorkItem?.cancel()
+        shippingHandlerWorkItem = nil
+
+        guard let handler = pendingShippingHandler else {
+            call.reject("No pending shipping handler")
+            return
+        }
+        pendingShippingHandler = nil
+
+        let rawItems = call.getArray("paymentSummaryItems", [String: Any].self) ?? []
+        var updatedItems: [PKPaymentSummaryItem] = []
+        for item in rawItems {
+            let label = item["label"] as? String ?? ""
+            if let amount = item["amount"] as? NSNumber {
+                updatedItems.append(PKPaymentSummaryItem(label: label, amount: NSDecimalNumber(decimal: amount.decimalValue)))
+            }
+        }
+        let itemsToUse = updatedItems.isEmpty ? (self.paymentRequest?.paymentSummaryItems ?? []) : updatedItems
+        handler(PKPaymentRequestShippingContactUpdate(paymentSummaryItems: itemsToUse))
+        call.resolve()
     }
 
     func applePayContext(_ context: STPApplePayContext, didCreatePaymentMethod paymentMethod: StripeAPI.PaymentMethod, paymentInformation: PKPayment) async throws -> String {

--- a/packages/payment/ios/Sources/StripePlugin/ApplePay/ApplePayExecutor.swift
+++ b/packages/payment/ios/Sources/StripePlugin/ApplePay/ApplePayExecutor.swift
@@ -11,6 +11,7 @@ class ApplePayExecutor: NSObject, ApplePayContextDelegate {
     private var allowedCountries: [String] = []
     private var allowedCountriesErrorDescription: String = ""
     private var pendingShippingHandler: ((PKPaymentRequestShippingContactUpdate) -> Void)?
+    private var pendingShippingUpdateId: String?
     private var shippingHandlerWorkItem: DispatchWorkItem?
 
     func isApplePayAvailable(_ call: CAPPluginCall) {
@@ -151,30 +152,46 @@ extension ApplePayExecutor {
 
         // Store handler so JS can call updateApplePaySheet with updated items
         shippingHandlerWorkItem?.cancel()
+        let updateId = UUID().uuidString
+        pendingShippingUpdateId = updateId
         pendingShippingHandler = handler
 
         // Fallback: resolve with original items after 25s if JS does not respond
         let workItem = DispatchWorkItem { [weak self] in
-            guard let self = self, let pendingHandler = self.pendingShippingHandler else { return }
+            guard let self = self,
+                  self.pendingShippingUpdateId == updateId,
+                  let pendingHandler = self.pendingShippingHandler else { return }
             self.pendingShippingHandler = nil
+            self.pendingShippingUpdateId = nil
+            self.shippingHandlerWorkItem = nil
             pendingHandler(PKPaymentRequestShippingContactUpdate(paymentSummaryItems: self.paymentRequest?.paymentSummaryItems ?? []))
         }
         shippingHandlerWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 25, execute: workItem)
 
         let jsonArray = self.transformPKContactToJSON(contact: contact)
-        self.plugin?.notifyListeners(ApplePayEvents.DidSelectShippingContact.rawValue, data: ["contact": jsonArray])
+        self.plugin?.notifyListeners(ApplePayEvents.DidSelectShippingContact.rawValue, data: ["contact": jsonArray, "updateId": updateId])
     }
 
     func updateApplePaySheet(_ call: CAPPluginCall) {
-        shippingHandlerWorkItem?.cancel()
-        shippingHandlerWorkItem = nil
-
-        guard let handler = pendingShippingHandler else {
-            call.reject("No pending shipping handler")
+        guard let updateId = call.getString("updateId"), !updateId.isEmpty else {
+            call.reject("Invalid Params. this method requires updateId")
             return
         }
+
+        guard let handler = pendingShippingHandler else {
+            call.reject("No pending shipping update")
+            return
+        }
+        guard pendingShippingUpdateId == updateId else {
+            call.reject("Stale shipping update")
+            return
+        }
+
+        shippingHandlerWorkItem?.cancel()
+        shippingHandlerWorkItem = nil
         pendingShippingHandler = nil
+        pendingShippingUpdateId = nil
 
         let rawItems = call.getArray("paymentSummaryItems", [String: Any].self) ?? []
         var updatedItems: [PKPaymentSummaryItem] = []
@@ -185,6 +202,7 @@ extension ApplePayExecutor {
             }
         }
         let itemsToUse = updatedItems.isEmpty ? (self.paymentRequest?.paymentSummaryItems ?? []) : updatedItems
+        self.paymentRequest?.paymentSummaryItems = itemsToUse
         handler(PKPaymentRequestShippingContactUpdate(paymentSummaryItems: itemsToUse))
         call.resolve()
     }
@@ -198,6 +216,13 @@ extension ApplePayExecutor {
     }
 
     func applePayContext(_ context: STPApplePayContext, didCompleteWith status: STPApplePayContext.PaymentStatus, error: Error?) {
+        shippingHandlerWorkItem?.cancel()
+        shippingHandlerWorkItem = nil
+        let shippingHandler = pendingShippingHandler
+        pendingShippingHandler = nil
+        pendingShippingUpdateId = nil
+        shippingHandler?(PKPaymentRequestShippingContactUpdate(paymentSummaryItems: self.paymentRequest?.paymentSummaryItems ?? []))
+
         if let callId = self.payCallId, let call = self.plugin?.bridge?.savedCall(withID: callId) {
             switch status {
             case .success:

--- a/packages/payment/ios/Sources/StripePlugin/StripePlugin.swift
+++ b/packages/payment/ios/Sources/StripePlugin/StripePlugin.swift
@@ -109,7 +109,9 @@ public class StripePlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func updateApplePaySheet(_ call: CAPPluginCall) {
-        self.applePayExecutor.updateApplePaySheet(call)
+        DispatchQueue.main.async {
+            self.applePayExecutor.updateApplePaySheet(call)
+        }
     }
 
     @objc func isGooglePayAvailable(_ call: CAPPluginCall) {

--- a/packages/payment/ios/Sources/StripePlugin/StripePlugin.swift
+++ b/packages/payment/ios/Sources/StripePlugin/StripePlugin.swift
@@ -18,6 +18,7 @@ public class StripePlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "isApplePayAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "createApplePay", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "presentApplePay", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "updateApplePaySheet", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isGooglePayAvailable", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "createGooglePay", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "presentGooglePay", returnType: CAPPluginReturnPromise)
@@ -105,6 +106,10 @@ public class StripePlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func presentApplePay(_ call: CAPPluginCall) {
         self.applePayExecutor.presentApplePay(call)
+    }
+
+    @objc func updateApplePaySheet(_ call: CAPPluginCall) {
+        self.applePayExecutor.updateApplePaySheet(call)
     }
 
     @objc func isGooglePayAvailable(_ call: CAPPluginCall) {

--- a/packages/payment/src/applepay/apple-pay-difinitions.interface.ts
+++ b/packages/payment/src/applepay/apple-pay-difinitions.interface.ts
@@ -1,6 +1,6 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
-import type {CreateApplePayOption, DidSelectShippingContact} from '../shared';
+import type { CreateApplePayOption, DidSelectShippingContact, PaymentSummaryItem } from '../shared';
 
 import type { ApplePayEventsEnum, ApplePayResultInterface } from './apple-pay-events.enum';
 
@@ -12,6 +12,8 @@ export interface ApplePayDefinitions {
   presentApplePay(): Promise<{
     paymentResult: ApplePayResultInterface;
   }>;
+
+  updateApplePaySheet(options: { paymentSummaryItems: PaymentSummaryItem[] }): Promise<void>;
 
   addListener(
     eventName: ApplePayEventsEnum.Loaded,

--- a/packages/payment/src/applepay/apple-pay-difinitions.interface.ts
+++ b/packages/payment/src/applepay/apple-pay-difinitions.interface.ts
@@ -1,6 +1,6 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
-import type { CreateApplePayOption, DidSelectShippingContact, PaymentSummaryItem } from '../shared';
+import type { CreateApplePayOption, DidCreatePaymentMethod, DidSelectShippingContact, PaymentSummaryItem } from '../shared';
 
 import type { ApplePayEventsEnum, ApplePayResultInterface } from './apple-pay-events.enum';
 
@@ -13,7 +13,7 @@ export interface ApplePayDefinitions {
     paymentResult: ApplePayResultInterface;
   }>;
 
-  updateApplePaySheet(options: { paymentSummaryItems: PaymentSummaryItem[] }): Promise<void>;
+  updateApplePaySheet(options: { updateId: string; paymentSummaryItems: PaymentSummaryItem[] }): Promise<void>;
 
   addListener(
     eventName: ApplePayEventsEnum.Loaded,
@@ -47,6 +47,6 @@ export interface ApplePayDefinitions {
 
   addListener(
     eventName: ApplePayEventsEnum.DidCreatePaymentMethod,
-    listenerFunc: (data: DidSelectShippingContact) => void,
+    listenerFunc: (data: DidCreatePaymentMethod) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -181,12 +181,14 @@ export interface BasePaymentOption {
   currencyCode?: string;
 }
 
+export interface PaymentSummaryItem {
+  label: string;
+  amount: number;
+}
+
 export interface CreateApplePayOption {
   paymentIntentClientSecret: string;
-  paymentSummaryItems: {
-    label: string;
-    amount: number;
-  }[];
+  paymentSummaryItems: PaymentSummaryItem[];
   merchantIdentifier: string;
   countryCode: string;
   currency: string;

--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -228,6 +228,10 @@ export interface CreateGooglePayOption {
 // Apple doc: https://developer.apple.com/documentation/passkit/pkcontact
 export interface DidSelectShippingContact {
   contact: ShippingContact;
+  updateId: string;
+}
+export interface DidCreatePaymentMethod {
+  contact: ShippingContact;
 }
 export interface ShippingContact {
   /**

--- a/packages/payment/src/web.ts
+++ b/packages/payment/src/web.ts
@@ -245,6 +245,10 @@ export class StripeWeb extends WebPlugin implements StripePlugin {
     }>;
   }
 
+  updateApplePaySheet(_options: { paymentSummaryItems: { label: string; amount: number }[] }): Promise<void> {
+    throw this.unimplemented('updateApplePaySheet is not supported on web.');
+  }
+
   isGooglePayAvailable(): Promise<void> {
     return this.isAvailable('googlePay');
   }

--- a/packages/payment/src/web.ts
+++ b/packages/payment/src/web.ts
@@ -245,7 +245,7 @@ export class StripeWeb extends WebPlugin implements StripePlugin {
     }>;
   }
 
-  updateApplePaySheet(_options: { paymentSummaryItems: { label: string; amount: number }[] }): Promise<void> {
+  updateApplePaySheet(_options: { updateId: string; paymentSummaryItems: { label: string; amount: number }[] }): Promise<void> {
     throw this.unimplemented('updateApplePaySheet is not supported on web.');
   }
 


### PR DESCRIPTION
## Problem

When a user selects a shipping contact in Apple Pay, the `didSelectShippingContact` delegate method receives a handler that **must** be called to update the payment sheet. The current implementation calls this handler immediately with empty items, making it impossible for the app to fetch updated pricing (e.g. shipping costs based on country) before resolving.

## Solution

Store the pending handler and expose a new `updateApplePaySheet` plugin method that JS can call with updated `paymentSummaryItems`. A 25-second timeout fallback resolves with the original items if JS does not respond in time.

## Changes

### iOS
- `ApplePayExecutor.swift`: store `pendingShippingHandler` instead of resolving immediately; validate `allowedCountries` first (immediate rejection if invalid); 25s timeout fallback via `DispatchWorkItem`
- `ApplePayExecutor.swift`: add `updateApplePaySheet` method that resolves the pending handler
- `StripePlugin.swift`: register `updateApplePaySheet` as a plugin method

### TypeScript
- `apple-pay-difinitions.interface.ts`: add `updateApplePaySheet(options: { paymentSummaryItems: PaymentSummaryItem[] }): Promise<void>`
- `shared/index.ts`: extract `PaymentSummaryItem` as a named exported interface (was inline in `CreateApplePayOption`)
- `web.ts`: add unimplemented stub for `updateApplePaySheet`

## Usage

```typescript
const shippingListener = await Stripe.addListener(
  ApplePayEventsEnum.DidSelectShippingContact,
  async (data) => {
    const country = data.contact.isoCountryCode.toUpperCase();
    const { amount } = await myBackend.getShippingCost(country);
    await Stripe.updateApplePaySheet({
      paymentSummaryItems: [{ label: 'Total', amount }],
    });
  },
);
```
