### PR TITLE
fix(terminal): wrong annotation for discoverReaders on android

### DIFF
--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
@@ -100,7 +100,7 @@ class StripeTerminalPlugin : Plugin() {
         }
     }
 
-    @PluginMethod(returnType = PluginMethod.RETURN_CALLBACK)
+    @PluginMethod
     fun discoverReaders(call: PluginCall) {
         if (call.getString("type") == TerminalConnectTypes.Bluetooth.webEventName || call.getString(
                 "type"


### PR DESCRIPTION
discoverReaders is annotated as returnType = PluginMethod.RETURN_CALLBACK, which conflicts with the example code showing a promise-type return.