### PR TITLE
feat(terminal): add isTapToPayAccountLinked for iOS, bump iOS SDK to 5.7.0

### DIFF
--- a/packages/terminal/CapacitorCommunityStripeTerminal.podspec
+++ b/packages/terminal/CapacitorCommunityStripeTerminal.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripeTerminal', '~> 5.3.0'
+  s.dependency 'StripeTerminal', '~> 5.7.0'
   s.swift_version = '5.1'
 end

--- a/packages/terminal/Package.swift
+++ b/packages/terminal/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/stripe/stripe-terminal-ios.git", .upToNextMinor(from: "5.3.0"))
+        .package(url: "https://github.com/stripe/stripe-terminal-ios.git", .upToNextMinor(from: "5.7.0"))
     ],
     targets: [
         .target(

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -213,6 +213,7 @@ await StripeTerminal.setSimulatorConfiguration({ update: SimulateReaderUpdate.Up
 * [`rebootReader()`](#rebootreader)
 * [`cancelReaderReconnection()`](#cancelreaderreconnection)
 * [`setTapToPayUxConfiguration(...)`](#settaptopayuxconfiguration)
+* [`isTapToPayAccountLinked(...)`](#istaptopayaccountlinked)
 * [`addListener(TerminalEventsEnum.Loaded, ...)`](#addlistenerterminaleventsenumloaded-)
 * [`addListener(TerminalEventsEnum.RequestedConnectionToken, ...)`](#addlistenerterminaleventsenumrequestedconnectiontoken-)
 * [`addListener(TerminalEventsEnum.DiscoveredReaders, ...)`](#addlistenerterminaleventsenumdiscoveredreaders-)
@@ -445,6 +446,34 @@ Has no effect on iOS or web platforms.
 | Param         | Type                                                                        |
 | ------------- | --------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#taptopayuxconfiguration">TapToPayUxConfiguration</a></code> |
+
+--------------------
+
+
+### isTapToPayAccountLinked(...)
+
+```typescript
+isTapToPayAccountLinked(options?: IsTapToPayAccountLinkedOptions | undefined) => Promise<{ isLinked: boolean; }>
+```
+
+Check whether the merchant has accepted Apple's Tap to Pay on iPhone
+Terms and Conditions.
+
+iOS only, and requires iOS 16.4 or later. `initialize()` must have been
+called first because the SDK needs a connection token provider, but no
+reader connection is required and the call does not activate the device.
+
+The answer is read from Apple on every call. Apple's Tap to Pay on iPhone
+requirements state that acceptance state must be retrieved from Apple
+rather than from a local variable, so do not cache the result.
+
+[*Stripe docs reference*](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)isTapToPayAccountLinked:completion:)
+
+| Param         | Type                                                                                      |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#istaptopayaccountlinkedoptions">IsTapToPayAccountLinkedOptions</a></code> |
+
+**Returns:** <code>Promise&lt;{ isLinked: boolean; }&gt;</code>
 
 --------------------
 
@@ -952,6 +981,15 @@ Color scheme for the Tap to Pay screen.
 | **`error`**   | <code><a href="#taptopaycolor">TapToPayColor</a></code> | Error state color. Hex string or 'default'.                  |
 
 
+#### IsTapToPayAccountLinkedOptions
+
+Options for isTapToPayAccountLinked.
+
+| Prop             | Type                | Description                                                                                          |
+| ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------- |
+| **`onBehalfOf`** | <code>string</code> | Connected account ID, for Stripe Connect platforms. Omit to check the account that owns the API key. |
+
+
 #### PluginListenerHandle
 
 | Prop         | Type                                      |
@@ -1062,7 +1100,6 @@ Controls where the tap indicator appears on screen.
 | **`stripeM2`**         | <code>'stripeM2'</code>         |
 | **`stripeS700`**       | <code>'stripeS700'</code>       |
 | **`stripeS700DevKit`** | <code>'stripeS700Devkit'</code> |
-| **`verifoneP400`**     | <code>'verifoneP400'</code>     |
 | **`wiseCube`**         | <code>'wiseCube'</code>         |
 | **`wisePad3`**         | <code>'wisePad3'</code>         |
 | **`wisePosE`**         | <code>'wisePosE'</code>         |

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
@@ -202,4 +202,9 @@ class StripeTerminalPlugin : Plugin() {
     fun setTapToPayUxConfiguration(call: PluginCall) {
         implementation.setTapToPayUxConfiguration(call)
     }
+
+    @PluginMethod
+    fun isTapToPayAccountLinked(call: PluginCall) {
+        call.unimplemented("isTapToPayAccountLinked is only supported on iOS.")
+    }
 }

--- a/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
+++ b/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
@@ -282,6 +282,26 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
         call.resolve([:])
     }
 
+    public func isTapToPayAccountLinked(_ call: CAPPluginCall) {
+        guard #available(iOS 16.4, *) else {
+            call.unavailable("isTapToPayAccountLinked requires iOS 16.4 or later.")
+            return
+        }
+
+        if self.isInitialize == false {
+            call.reject("Stripe Terminal is not initialized. Call initialize() first.")
+            return
+        }
+
+        Terminal.shared.isTapToPayAccountLinked(call.getString("onBehalfOf")) { isLinked, error in
+            if let error = error {
+                call.reject(error.localizedDescription)
+                return
+            }
+            call.resolve(["isLinked": isLinked?.boolValue ?? false])
+        }
+    }
+
     public func installAvailableUpdate(_ call: CAPPluginCall) {
         Terminal.shared.installAvailableUpdate()
         call.resolve([:])

--- a/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminalPlugin.swift
+++ b/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminalPlugin.swift
@@ -25,7 +25,8 @@ public class StripeTerminalPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "clearReaderDisplay", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "rebootReader", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "cancelReaderReconnection", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "setTapToPayUxConfiguration", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "setTapToPayUxConfiguration", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "isTapToPayAccountLinked", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = StripeTerminal()
 
@@ -109,5 +110,9 @@ public class StripeTerminalPlugin: CAPPlugin, CAPBridgedPlugin {
     
     @objc func setTapToPayUxConfiguration(_ call: CAPPluginCall) {
         call.unimplemented()
+    }
+
+    @objc func isTapToPayAccountLinked(_ call: CAPPluginCall) {
+        self.implementation.isTapToPayAccountLinked(call)
     }
 }

--- a/packages/terminal/src/definitions.ts
+++ b/packages/terminal/src/definitions.ts
@@ -143,6 +143,17 @@ export interface TapToPayUxConfiguration {
   tapZone?: TapToPayTapZone;
 }
 
+/**
+ * Options for isTapToPayAccountLinked.
+ */
+export interface IsTapToPayAccountLinkedOptions {
+  /**
+   * Connected account ID, for Stripe Connect platforms.
+   * Omit to check the account that owns the API key.
+   */
+  onBehalfOf?: string;
+}
+
 export interface DiscoverReadersOptions {
   type: TerminalConnectTypes;
   locationId?: string;
@@ -211,6 +222,22 @@ export interface StripeTerminalPlugin {
    * Has no effect on iOS or web platforms.
    */
   setTapToPayUxConfiguration(options: TapToPayUxConfiguration): Promise<void>;
+
+  /**
+   * Check whether the merchant has accepted Apple's Tap to Pay on iPhone
+   * Terms and Conditions.
+   *
+   * iOS only, and requires iOS 16.4 or later. `initialize()` must have been
+   * called first because the SDK needs a connection token provider, but no
+   * reader connection is required and the call does not activate the device.
+   *
+   * The answer is read from Apple on every call. Apple's Tap to Pay on iPhone
+   * requirements state that acceptance state must be retrieved from Apple
+   * rather than from a local variable, so do not cache the result.
+   *
+   * [*Stripe docs reference*](https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)isTapToPayAccountLinked:completion:)
+   */
+  isTapToPayAccountLinked(options?: IsTapToPayAccountLinkedOptions): Promise<{ isLinked: boolean }>;
 
   addListener(eventName: TerminalEventsEnum.Loaded, listenerFunc: () => void): Promise<PluginListenerHandle>;
 

--- a/packages/terminal/src/web.ts
+++ b/packages/terminal/src/web.ts
@@ -11,6 +11,7 @@ import type {
   SimulatedCardType,
   Cart,
   TapToPayUxConfiguration,
+  IsTapToPayAccountLinkedOptions,
 } from './definitions';
 import { TerminalEventsEnum } from './events.enum';
 import {
@@ -217,5 +218,9 @@ export class StripeTerminalWeb extends WebPlugin implements StripeTerminalPlugin
 
   async setTapToPayUxConfiguration(_options: TapToPayUxConfiguration): Promise<void> {
     console.log('setTapToPayUxConfiguration is only supported on Android');
+  }
+
+  async isTapToPayAccountLinked(_options?: IsTapToPayAccountLinkedOptions): Promise<{ isLinked: boolean }> {
+    throw this.unavailable('isTapToPayAccountLinked is only supported on iOS.');
   }
 }


### PR DESCRIPTION
## Problem

`isTapToPayAccountLinked` is unreachable from JavaScript today, for two separate reasons.

1. The plugin pins `StripeTerminal` at `~> 5.3.0` in the podspec and `.upToNextMinor(from: "5.3.0")` in `Package.swift`, so it resolves 5.3.x. The API was added in Stripe Terminal iOS SDK 5.5.0.
2. Even against a newer SDK, the plugin does not bridge the method at all.

Apple's Tap to Pay on iPhone requirement 5.1.6 asks the app to read Terms and Conditions acceptance state from Apple, and states that it must not be read from a local variable in the app. `isTapToPayAccountLinked` is the API Stripe provides for that, so an integrator using this plugin currently has no way to satisfy the requirement. Both changes are needed; bumping the pin alone does nothing.

## Changes

**SDK pin.** `Package.swift` and `CapacitorCommunityStripeTerminal.podspec` move to 5.7.0, the current release. 5.6.x is skipped deliberately: Stripe deprecated 5.6.0 because its offline database migration can delete stored offline payments.

**New method.** `isTapToPayAccountLinked(options?: { onBehalfOf?: string }): Promise<{ isLinked: boolean }>`

* iOS calls `Terminal.shared.isTapToPayAccountLinked(_:completion:)`. It is guarded with `#available(iOS 16.4, *)` because the SDK marks the method `API_AVAILABLE(ios(16.4))` while the plugin deployment target is 15.0. It rejects if `initialize()` has not run, since the SDK needs a connection token provider. If the SDK returns an error the call rejects instead of resolving, matching Stripe's note that `isLinked` is meaningless when the error is non-nil.
* Android returns `call.unimplemented(...)`, mirroring how iOS handles the Android-only `setTapToPayUxConfiguration`.
* Web throws `this.unavailable(...)`, the same pattern already used by `discoverReaders`. It deliberately does not resolve a value, because a fabricated `false` is exactly the locally-held answer requirement 5.1.6 forbids.

`README.md` is regenerated by `npm run build`. That also drops a stale `verifoneP400` row which no longer exists in `src/stripe.enum.ts`.

Android is otherwise untouched: the SDK pins in `android/build.gradle` stay at `5.3.+`.

## Verification

* `npm run build` in `packages/terminal` (tsc, rollup, docgen).
* `npm run verify:ios`, that is `xcodebuild -scheme CapacitorCommunityStripeTerminal -destination generic/platform=iOS`, resolving the 5.7.0 binary target. Build succeeds. The 5.3 to 5.7 jump produced no compile errors. The only new diagnostic is a deprecation warning on `simulatorConfiguration.availableReaderUpdate`, deprecated in 5.5.0 in favour of the per-connection `testReaderUpdate`. I left it alone since changing it would change behaviour and is out of scope.
* `npm run eslint` and `npm run prettier -- --check` are clean. SwiftLint was not installed locally, so the Swift is not lint-checked.
* Consumed the branch from a real Capacitor 8 app as a local `file:` dependency, then `npx cap sync ios` plus an Xcode build (succeeds, resolving 5.7.0), and `npx cap sync android` plus a Gradle build of the plugin module (succeeds).

Not verified: I have not exercised `isTapToPayAccountLinked` on physical hardware. Tap to Pay requires an iPhone XS or later with the entitlement provisioned and does not work in the simulator, so the change is compile-verified and wired end to end, but the runtime result on a device is untested.
