### PR TITLE
fix(terminal): settle reader discovery cancellation

### DIFF
--- a/demo/angular/android/gradle.properties
+++ b/demo/angular/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx3072m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
@@ -72,6 +72,7 @@ class StripeTerminal(
 ) {
     private var tokenProvider: TokenProvider? = null
     private var discoveryCancelable: Cancelable? = null
+    private var discoveryGeneration = 0
     private var collectCancelable: Cancelable? = null
     private var installUpdateCancelable: Cancelable? = null
     private var cancelReaderConnectionCancellable: Cancelable? = null
@@ -206,6 +207,7 @@ class StripeTerminal(
             return
         }
 
+        val generation = ++discoveryGeneration
         discoveryCancelable = Terminal.getInstance()
             .discoverReaders(
                 config,
@@ -228,12 +230,12 @@ class StripeTerminal(
                 },
                 object : Callback {
                     override fun onSuccess() {
-                        discoveryCancelable = null
+                        if (discoveryGeneration == generation) discoveryCancelable = null
                         Log.d(logTag, "Finished discovering readers")
                     }
 
                     override fun onFailure(e: TerminalException) {
-                        discoveryCancelable = null
+                        if (discoveryGeneration == generation) discoveryCancelable = null
                         Log.d(logTag, e.localizedMessage)
                     }
                 }
@@ -491,10 +493,11 @@ class StripeTerminal(
             return
         }
         val cancelable = discoveryCancelable!!
-        discoveryCancelable = null
+        val generation = discoveryGeneration
         cancelable.cancel(
             object : Callback {
                 override fun onSuccess() {
+                    if (discoveryGeneration == generation) discoveryCancelable = null
                     notifyListeners(
                         TerminalEnumEvent.CancelDiscoveredReaders.webEventName,
                         emptyObject

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
@@ -72,7 +72,7 @@ class StripeTerminal(
 ) {
     private var tokenProvider: TokenProvider? = null
     private var discoveryCancelable: Cancelable? = null
-    private var discoveryGeneration = 0
+    private var discoveryToken: Any? = null
     private var collectCancelable: Cancelable? = null
     private var installUpdateCancelable: Cancelable? = null
     private var cancelReaderConnectionCancellable: Cancelable? = null
@@ -207,7 +207,8 @@ class StripeTerminal(
             return
         }
 
-        val generation = ++discoveryGeneration
+        val token = Any()
+        discoveryToken = token
         discoveryCancelable = Terminal.getInstance()
             .discoverReaders(
                 config,
@@ -230,12 +231,18 @@ class StripeTerminal(
                 },
                 object : Callback {
                     override fun onSuccess() {
-                        if (discoveryGeneration == generation) discoveryCancelable = null
+                        if (discoveryToken === token) {
+                            discoveryCancelable = null
+                            discoveryToken = null
+                        }
                         Log.d(logTag, "Finished discovering readers")
                     }
 
                     override fun onFailure(e: TerminalException) {
-                        if (discoveryGeneration == generation) discoveryCancelable = null
+                        if (discoveryToken === token) {
+                            discoveryCancelable = null
+                            discoveryToken = null
+                        }
                         Log.d(logTag, e.localizedMessage)
                     }
                 }
@@ -489,15 +496,19 @@ class StripeTerminal(
     fun cancelDiscoverReaders(call: PluginCall) {
         if (discoveryCancelable == null || discoveryCancelable!!.isCompleted) {
             discoveryCancelable = null
+            discoveryToken = null
             call.resolve()
             return
         }
         val cancelable = discoveryCancelable!!
-        val generation = discoveryGeneration
+        val token = discoveryToken
         cancelable.cancel(
             object : Callback {
                 override fun onSuccess() {
-                    if (discoveryGeneration == generation) discoveryCancelable = null
+                    if (discoveryToken === token) {
+                        discoveryCancelable = null
+                        discoveryToken = null
+                    }
                     notifyListeners(
                         TerminalEnumEvent.CancelDiscoveredReaders.webEventName,
                         emptyObject

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
@@ -70,9 +70,11 @@ class StripeTerminal(
     pluginLogTag,
     "StripeTerminalExecutor"
 ) {
+    private class DiscoveryToken
+
     private var tokenProvider: TokenProvider? = null
     private var discoveryCancelable: Cancelable? = null
-    private var discoveryToken: Any? = null
+    private var discoveryToken: DiscoveryToken? = null
     private var collectCancelable: Cancelable? = null
     private var installUpdateCancelable: Cancelable? = null
     private var cancelReaderConnectionCancellable: Cancelable? = null
@@ -207,7 +209,7 @@ class StripeTerminal(
             return
         }
 
-        val token = Any()
+        val token = DiscoveryToken()
         discoveryToken = token
         discoveryCancelable = Terminal.getInstance()
             .discoverReaders(

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
@@ -228,10 +228,12 @@ class StripeTerminal(
                 },
                 object : Callback {
                     override fun onSuccess() {
+                        discoveryCancelable = null
                         Log.d(logTag, "Finished discovering readers")
                     }
 
                     override fun onFailure(e: TerminalException) {
+                        discoveryCancelable = null
                         Log.d(logTag, e.localizedMessage)
                     }
                 }
@@ -484,10 +486,13 @@ class StripeTerminal(
 
     fun cancelDiscoverReaders(call: PluginCall) {
         if (discoveryCancelable == null || discoveryCancelable!!.isCompleted) {
+            discoveryCancelable = null
             call.resolve()
             return
         }
-        discoveryCancelable!!.cancel(
+        val cancelable = discoveryCancelable!!
+        discoveryCancelable = null
+        cancelable.cancel(
             object : Callback {
                 override fun onSuccess() {
                     notifyListeners(

--- a/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
+++ b/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
@@ -80,6 +80,7 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
         }
         
         self.discoverCancelable = Terminal.shared.discoverReaders(config, delegate: self) { error in
+            self.discoverCancelable = nil
             if let error = error {
                 print("discoverReaders failed: \(error)")
                 call.reject(error.localizedDescription)
@@ -412,9 +413,11 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
     func cancelDiscoverReaders(_ call: CAPPluginCall) {
         if let cancelable = self.discoverCancelable {
             if cancelable.completed {
+                self.discoverCancelable = nil
                 call.resolve()
                 return
             }
+            self.discoverCancelable = nil
             cancelable.cancel { error in
                 if let error = error {
                     call.reject(error.localizedDescription)

--- a/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
+++ b/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
@@ -8,6 +8,7 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
     private let apiClient = APIClient()
 
     var discoverCancelable: Cancelable?
+    private var discoveryGeneration = 0
     var collectCancelable: Cancelable?
     var installUpdateCancelable: Cancelable?
     var cancelReaderConnectionCancellable: Cancelable?
@@ -79,8 +80,12 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
             self.discoverCall = call
         }
         
+        self.discoveryGeneration += 1
+        let generation = self.discoveryGeneration
         self.discoverCancelable = Terminal.shared.discoverReaders(config, delegate: self) { error in
-            self.discoverCancelable = nil
+            if self.discoveryGeneration == generation {
+                self.discoverCancelable = nil
+            }
             if let error = error {
                 print("discoverReaders failed: \(error)")
                 call.reject(error.localizedDescription)
@@ -417,11 +422,14 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
                 call.resolve()
                 return
             }
-            self.discoverCancelable = nil
+            let generation = self.discoveryGeneration
             cancelable.cancel { error in
                 if let error = error {
                     call.reject(error.localizedDescription)
                 } else {
+                    if self.discoveryGeneration == generation {
+                        self.discoverCancelable = nil
+                    }
                     self.plugin?.notifyListeners(TerminalEvents.CancelDiscoveredReaders.rawValue, data: [:])
                     call.resolve()
                 }

--- a/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
+++ b/packages/terminal/ios/Sources/StripeTerminalPlugin/StripeTerminal.swift
@@ -4,11 +4,13 @@ import StripeTerminal
 
 public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, ReaderDelegate, MobileReaderDelegate, TapToPayReaderDelegate, InternetReaderDelegate {
 
+    private final class DiscoveryToken {}
+
     weak var plugin: StripeTerminalPlugin?
     private let apiClient = APIClient()
 
     var discoverCancelable: Cancelable?
-    private var discoveryGeneration = 0
+    private var discoveryToken: DiscoveryToken?
     var collectCancelable: Cancelable?
     var installUpdateCancelable: Cancelable?
     var cancelReaderConnectionCancellable: Cancelable?
@@ -80,11 +82,12 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
             self.discoverCall = call
         }
         
-        self.discoveryGeneration += 1
-        let generation = self.discoveryGeneration
+        let token = DiscoveryToken()
+        self.discoveryToken = token
         self.discoverCancelable = Terminal.shared.discoverReaders(config, delegate: self) { error in
-            if self.discoveryGeneration == generation {
+            if self.discoveryToken === token {
                 self.discoverCancelable = nil
+                self.discoveryToken = nil
             }
             if let error = error {
                 print("discoverReaders failed: \(error)")
@@ -419,16 +422,18 @@ public class StripeTerminal: NSObject, DiscoveryDelegate, TerminalDelegate, Read
         if let cancelable = self.discoverCancelable {
             if cancelable.completed {
                 self.discoverCancelable = nil
+                self.discoveryToken = nil
                 call.resolve()
                 return
             }
-            let generation = self.discoveryGeneration
+            let token = self.discoveryToken
             cancelable.cancel { error in
                 if let error = error {
                     call.reject(error.localizedDescription)
                 } else {
-                    if self.discoveryGeneration == generation {
+                    if self.discoveryToken === token {
                         self.discoverCancelable = nil
+                        self.discoveryToken = nil
                     }
                     self.plugin?.notifyListeners(TerminalEvents.CancelDiscoveredReaders.rawValue, data: [:])
                     call.resolve()


### PR DESCRIPTION
## Summary

- clear the stored discovery cancelable when native discovery finishes
- clear the handle before cancellation so completed discovery is treated as inactive
- keep Android and iOS cancellation behavior aligned

## Root cause

The plugin retained `discoverCancelable` after discovery completed. A later `cancelDiscoverReaders()` call could therefore invoke `cancel()` on a stale completed operation and wait indefinitely for its callback with Stripe Terminal SDK 5.x.

## Impact

Calling `cancelDiscoverReaders()` when discovery is no longer active now resolves immediately, and a new discovery can start after cancellation.

## Validation

- `npm run build -w packages/terminal`
- iOS Swift package build for `arm64-apple-ios15.0`
- Android `./gradlew clean build test` with JDK 21
- `git diff --check`

The package-wide lint command still reports existing SwiftLint violations outside this change.

Closes #475
