### PR TITLE
fix(payment): ignore completed flow option reset

### DIFF
--- a/packages/payment/android/build.gradle
+++ b/packages/payment/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
-    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '23.1.+'
+    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '23.15.+'
     gsonVersion = project.hasProperty('gsonVersion') ? rootProject.ext.gsonVersion : '2.10.+'
 }
 

--- a/packages/payment/android/build.gradle
+++ b/packages/payment/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
-    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '23.15.+'
+    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '23.1.+'
     gsonVersion = project.hasProperty('gsonVersion') ? rootProject.ext.gsonVersion : '2.10.+'
 }
 

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.kt
@@ -18,7 +18,6 @@ import com.stripe.android.core.AppInfo
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
-import com.stripe.android.paymentsheet.model.PaymentOption
 
 @NativePlugin(name = "Stripe", requestCodes = [9972, 50000, 50001, 6000])
 class StripePlugin : Plugin() {
@@ -96,15 +95,19 @@ class StripePlugin : Plugin() {
             paymentSheetExecutor.onPaymentSheetResult(bridge, paymentSheetCallbackId, result)
         }
 
-        paymentFlowExecutor.flowController = PaymentSheet.FlowController.create(
-            activity,
-            { paymentOption: PaymentOption? ->
-                paymentFlowExecutor.onPaymentOption(bridge, paymentFlowCallbackId, paymentOption)
-            },
-            { result: PaymentSheetResult ->
+        paymentFlowExecutor.flowController = PaymentSheet.FlowController.Builder(
+            resultCallback = { result: PaymentSheetResult ->
                 paymentFlowExecutor.onPaymentFlowResult(bridge, paymentFlowCallbackId, result)
+            },
+            paymentOptionResultCallback = { result ->
+                paymentFlowExecutor.onPaymentOption(
+                    bridge,
+                    paymentFlowCallbackId,
+                    result.paymentOption,
+                    result.didCancel
+                )
             }
-        )
+        ).build(activity)
 
         if (metaData.enableIdentifier) {
             val resources = activity.applicationContext.resources

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/paymentflow/PaymentFlowExecutor.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/paymentflow/PaymentFlowExecutor.kt
@@ -14,6 +14,9 @@ import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.model.PaymentOption
 
+internal fun shouldIgnorePaymentOptionResult(hasPaymentOption: Boolean, didCancel: Boolean): Boolean =
+    !hasPaymentOption && !didCancel
+
 class PaymentFlowExecutor(
     contextSupplier: Supplier<Context>,
     activitySupplier: Supplier<Activity>,
@@ -169,7 +172,14 @@ class PaymentFlowExecutor(
         }
     }
 
-    fun onPaymentOption(bridge: Bridge, callbackId: String?, paymentOption: PaymentOption?) {
+    fun onPaymentOption(
+        bridge: Bridge,
+        callbackId: String?,
+        paymentOption: PaymentOption?,
+        didCancel: Boolean
+    ) {
+        if (shouldIgnorePaymentOptionResult(paymentOption != null, didCancel)) return
+
         val call = bridge.getSavedCall(callbackId)
         if (paymentOption != null) {
             notifyListenersFunction.accept(

--- a/packages/payment/android/src/test/java/com/getcapacitor/community/stripe/paymentflow/PaymentOptionResultTest.kt
+++ b/packages/payment/android/src/test/java/com/getcapacitor/community/stripe/paymentflow/PaymentOptionResultTest.kt
@@ -1,0 +1,22 @@
+package com.getcapacitor.community.stripe.paymentflow
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaymentOptionResultTest {
+    @Test
+    fun completedPaymentOptionResetIsIgnored() {
+        assertTrue(shouldIgnorePaymentOptionResult(hasPaymentOption = false, didCancel = false))
+    }
+
+    @Test
+    fun canceledPaymentOptionIsNotIgnored() {
+        assertFalse(shouldIgnorePaymentOptionResult(hasPaymentOption = false, didCancel = true))
+    }
+
+    @Test
+    fun selectedPaymentOptionIsNotIgnored() {
+        assertFalse(shouldIgnorePaymentOptionResult(hasPaymentOption = true, didCancel = false))
+    }
+}


### PR DESCRIPTION
## Summary

- use `PaymentOptionResultCallback` to distinguish user cancellation from a completed-flow reset
- ignore only the null payment option emitted after successful confirmation
- keep the existing stripe-android 23.1.x default range

## Root cause

Since stripe-android 23.2.0, `PaymentSheet.FlowController` emits a null payment option after successful confirmation to keep merchant state aligned with its cleared internal state. The plugin treated every null payment option as a user cancellation, so consumers overriding the SDK to 23.2.0 or later could receive `paymentFlowCanceled` before `paymentFlowCompleted`.

## Impact

Successful payment flows no longer emit a spurious cancellation event. Explicit user cancellation and selected payment option events keep their existing behavior.

## Validation

- Android `./gradlew clean build` with the default stripe-android 23.1.x range
- Android `./gradlew testDebugUnitTest -PstripeAndroidVersion=23.15.0`
- `git diff --check`

Related upstream issue: https://github.com/stripe/stripe-android/issues/12809
