### PR TITLE
fix(android): retain results when saved calls are missing

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -31,11 +31,11 @@ see more details on Stripe's native Android SDK page [here](https://stripe.com/d
 If you want to implement, we recommend to read https://stripe.com/docs/identity .
 
 ```ts
-import { StripeIdentity } from '@capacitor-community/stripe-identity';
+import { IdentityVerificationSheetEventsEnum, StripeIdentity } from '@capacitor-community/stripe-identity';
 
-const listener = await StripeIdentity.addListener(IdentityVerificationSheetEventsEnum.VerificationResult, (result) => {
+// Register once per JavaScript application startup, as early as possible during bootstrap.
+const verificationResultListener = await StripeIdentity.addListener(IdentityVerificationSheetEventsEnum.VerificationResult, (result) => {
   console.log(result);
-  listener.remove();
 });
 
 // initialize is needed only for Web Platform
@@ -49,7 +49,17 @@ await StripeIdentity.create({
   clientSecret
 });
 await StripeIdentity.present();
+
+// Keep verificationResultListener and remove it only when its application-level owner is destroyed.
 ```
+
+### Android activity recreation
+
+Register the `VerificationResult` listener once per JavaScript application startup, as early as possible during bootstrap—for example, from `main.ts`, an application initializer, or a singleton service initialized at startup—and before calling `present()`.
+
+On Android, the Activity and JavaScript runtime can be recreated while Stripe Identity is open. If Stripe delivers the verification result to the recreated Activity before the new JavaScript runtime has registered its listener, the plugin retains the result until the bootstrap listener is available.
+
+This is an in-memory handoff of the native result. It is not persistent storage and does not guarantee recovery after OS process death or when Stripe does not deliver a result to the recreated Activity.
 
 ## API
 

--- a/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentity.kt
+++ b/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentity.kt
@@ -7,19 +7,19 @@ import com.getcapacitor.Bridge
 import com.getcapacitor.JSObject
 import com.getcapacitor.Logger
 import com.getcapacitor.PluginCall
+import com.getcapacitor.community.stripe.identity.models.EventNotifier
 import com.getcapacitor.community.stripe.identity.models.Executor
-import com.google.android.gms.common.util.BiConsumer
 import com.stripe.android.identity.IdentityVerificationSheet
 
 class StripeIdentity(
     contextSupplier: Supplier<Context>,
     activitySupplier: Supplier<Activity>,
-    notifyListenersFunction: BiConsumer<String, JSObject>,
+    eventNotifier: EventNotifier,
     pluginLogTag: String
 ) : Executor(
     contextSupplier,
     activitySupplier,
-    notifyListenersFunction,
+    eventNotifier,
     pluginLogTag,
     "StripeIdentityExecutor"
 ) {
@@ -74,7 +74,8 @@ class StripeIdentity(
             JSObject().put(
                 "result",
                 IdentityVerificationSheetEvent.Completed.webEventName
-            )
+            ),
+            true
         )
     }
 
@@ -83,7 +84,8 @@ class StripeIdentity(
             JSObject().put(
                 "result",
                 IdentityVerificationSheetEvent.Canceled.webEventName
-            )
+            ),
+            true
         )
     }
 
@@ -97,7 +99,8 @@ class StripeIdentity(
                 .put(
                     "error",
                     JSObject().put("message", errorMessage)
-                )
+                ),
+            true
         )
     }
 }

--- a/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentityPlugin.kt
+++ b/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/StripeIdentityPlugin.kt
@@ -7,6 +7,7 @@ import com.getcapacitor.Plugin
 import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
+import com.getcapacitor.community.stripe.identity.models.EventNotifier
 import com.stripe.android.identity.IdentityVerificationSheet
 import com.stripe.android.identity.IdentityVerificationSheet.Companion.create
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowResult
@@ -16,7 +17,9 @@ class StripeIdentityPlugin : Plugin() {
     private val implementation = StripeIdentity(
         { this.context },
         { this.activity },
-        { eventName: String?, data: JSObject? -> this.notifyListeners(eventName, data) },
+        EventNotifier { eventName, data, retainUntilConsumed ->
+            this.notifyListeners(eventName, data, retainUntilConsumed)
+        },
         logTag
     )
 

--- a/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/models/Executor.kt
+++ b/packages/identity/android/src/main/java/com/getcapacitor/community/stripe/identity/models/Executor.kt
@@ -4,19 +4,29 @@ import android.app.Activity
 import android.content.Context
 import androidx.core.util.Supplier
 import com.getcapacitor.JSObject
-import com.google.android.gms.common.util.BiConsumer
+
+fun interface EventNotifier {
+    fun accept(eventName: String, data: JSObject, retainUntilConsumed: Boolean)
+
+    fun accept(eventName: String, data: JSObject) {
+        accept(eventName, data, false)
+    }
+}
 
 abstract class Executor(
     protected var contextSupplier: Supplier<Context>,
     protected val activitySupplier: Supplier<Activity>,
-    protected var notifyListenersFunction: BiConsumer<String, JSObject>,
+    protected var notifyListenersFunction: EventNotifier,
     pluginLogTag: String,
     executorTag: String
 ) {
     protected val logTag: String = "$pluginLogTag|$executorTag"
 
-    // Eventually we can change the notification directly here!
-    protected fun notifyListeners(eventName: String, data: JSObject) {
-        notifyListenersFunction.accept(eventName, data)
+    protected fun notifyListeners(
+        eventName: String,
+        data: JSObject,
+        retainUntilConsumed: Boolean = false
+    ) {
+        notifyListenersFunction.accept(eventName, data, retainUntilConsumed)
     }
 }

--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -15,6 +15,30 @@ Learn at [the official @capacitor-community/stripe documentation](https://stripe
 
 日本語版をご利用の際は [ja.stripe.capacitorjs.jp](https://ja.stripe.capacitorjs.jp/) をご確認ください。
 
+### Recommended result handling
+
+Use result events as the default result path. Register application-level result listeners once per JavaScript application startup, as early as possible during bootstrap—for example, from `main.ts`, an application initializer, or a singleton service initialized at startup—and before presenting Stripe UI.
+
+```ts
+import { PaymentSheetEventsEnum, Stripe } from '@capacitor-community/stripe';
+
+await Promise.all([
+  Stripe.addListener(PaymentSheetEventsEnum.Completed, () => handleCompleted()),
+  Stripe.addListener(PaymentSheetEventsEnum.Canceled, () => handleCanceled()),
+  Stripe.addListener(PaymentSheetEventsEnum.Failed, (error) => handleFailed(error)),
+]);
+
+await Stripe.presentPaymentSheet();
+```
+
+### Android activity recreation
+
+This is especially important on Android, where the Activity and JavaScript runtime can be recreated while Stripe's UI is open. The new JavaScript runtime must register its listeners during bootstrap.
+
+The original JavaScript Promise and Capacitor `PluginCall` cannot be restored. If Stripe delivers the native result after recreation, the plugin retains the corresponding result event until a listener is available. This applies to the `Completed`, `Canceled`, and `Failed` events for PaymentSheet, PaymentFlow, and Google Pay, and to the `Created` event for PaymentFlow.
+
+If the original call still exists, behavior is unchanged: the Promise is settled normally and the event is delivered without being retained. This fallback is an in-memory handoff of a native result; it is not persistent storage and does not guarantee recovery after OS process death.
+
 ## API
 
 <docgen-index>

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/StripePlugin.kt
@@ -10,6 +10,7 @@ import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.getcapacitor.community.stripe.googlepay.GooglePayExecutor
 import com.getcapacitor.community.stripe.helper.MetaData
+import com.getcapacitor.community.stripe.models.EventNotifier
 import com.getcapacitor.community.stripe.paymentflow.PaymentFlowExecutor
 import com.getcapacitor.community.stripe.paymentsheet.PaymentSheetExecutor
 import com.stripe.android.PaymentConfiguration
@@ -33,21 +34,27 @@ class StripePlugin : Plugin() {
     private val paymentSheetExecutor = PaymentSheetExecutor(
         { this.context },
         { this.activity },
-        { eventName: String?, data: JSObject? -> this.notifyListeners(eventName, data) },
+        EventNotifier { eventName, data, retainUntilConsumed ->
+            this.notifyListeners(eventName, data, retainUntilConsumed)
+        },
         logTag
     )
 
     private val paymentFlowExecutor = PaymentFlowExecutor(
         { this.context },
         { this.activity },
-        { eventName: String?, data: JSObject? -> this.notifyListeners(eventName, data) },
+        EventNotifier { eventName, data, retainUntilConsumed ->
+            this.notifyListeners(eventName, data, retainUntilConsumed)
+        },
         logTag
     )
 
     private val googlePayExecutor = GooglePayExecutor(
         { this.context },
         { this.activity },
-        { eventName: String?, data: JSObject? -> this.notifyListeners(eventName, data) },
+        EventNotifier { eventName, data, retainUntilConsumed ->
+            this.notifyListeners(eventName, data, retainUntilConsumed)
+        },
         logTag
     )
 

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/googlepay/GooglePayExecutor.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/googlepay/GooglePayExecutor.kt
@@ -6,14 +6,14 @@ import androidx.core.util.Supplier
 import com.getcapacitor.Bridge
 import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
+import com.getcapacitor.community.stripe.models.EventNotifier
 import com.getcapacitor.community.stripe.models.Executor
-import com.google.android.gms.common.util.BiConsumer
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
 
 class GooglePayExecutor(
     contextSupplier: Supplier<Context>,
     activitySupplier: Supplier<Activity>,
-    notifyListenersFunction: BiConsumer<String, JSObject>,
+    notifyListenersFunction: EventNotifier,
     pluginLogTag: String
 ) : Executor(
     contextSupplier,
@@ -67,21 +67,26 @@ class GooglePayExecutor(
         }
     }
 
-    fun onGooglePayResult(bridge: Bridge, callbackId: String?, result: GooglePayLauncher.Result) {
+    fun onGooglePayResult(
+        bridge: Bridge,
+        callbackId: String?,
+        result: GooglePayLauncher.Result
+    ) {
         val call = bridge.getSavedCall(callbackId)
 
         if (result is GooglePayLauncher.Result.Completed) {
-            notifyListenersFunction.accept(GooglePayEvents.Completed.webEventName, emptyObject)
-            call.resolve(JSObject().put("paymentResult", GooglePayEvents.Completed.webEventName))
+            notifyListenersFunction.accept(GooglePayEvents.Completed.webEventName, emptyObject, call == null)
+            call?.resolve(JSObject().put("paymentResult", GooglePayEvents.Completed.webEventName))
         } else if (result is GooglePayLauncher.Result.Canceled) {
-            notifyListenersFunction.accept(GooglePayEvents.Canceled.webEventName, emptyObject)
-            call.resolve(JSObject().put("paymentResult", GooglePayEvents.Canceled.webEventName))
+            notifyListenersFunction.accept(GooglePayEvents.Canceled.webEventName, emptyObject, call == null)
+            call?.resolve(JSObject().put("paymentResult", GooglePayEvents.Canceled.webEventName))
         } else if (result is GooglePayLauncher.Result.Failed) {
             notifyListenersFunction.accept(
                 GooglePayEvents.Failed.webEventName,
-                JSObject().put("error", (result.error.localizedMessage))
+                JSObject().put("error", (result.error.localizedMessage)),
+                call == null
             )
-            call.resolve(JSObject().put("paymentResult", GooglePayEvents.Failed.webEventName))
+            call?.resolve(JSObject().put("paymentResult", GooglePayEvents.Failed.webEventName))
         }
     }
 }

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/models/Executor.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/models/Executor.kt
@@ -4,19 +4,29 @@ import android.app.Activity
 import android.content.Context
 import androidx.core.util.Supplier
 import com.getcapacitor.JSObject
-import com.google.android.gms.common.util.BiConsumer
+
+fun interface EventNotifier {
+    fun accept(eventName: String, data: JSObject, retainUntilConsumed: Boolean)
+
+    fun accept(eventName: String, data: JSObject) {
+        accept(eventName, data, false)
+    }
+}
 
 abstract class Executor(
     protected var contextSupplier: Supplier<Context>,
     protected val activitySupplier: Supplier<Activity>,
-    protected var notifyListenersFunction: BiConsumer<String, JSObject>,
+    protected var notifyListenersFunction: EventNotifier,
     pluginLogTag: String,
     executorTag: String
 ) {
     protected val logTag: String = "$pluginLogTag|$executorTag"
 
-    // Eventually we can change the notification directly here!
-    protected fun notifyListeners(eventName: String, data: JSObject) {
-        notifyListenersFunction.accept(eventName, data)
+    protected fun notifyListeners(
+        eventName: String,
+        data: JSObject,
+        retainUntilConsumed: Boolean = false
+    ) {
+        notifyListenersFunction.accept(eventName, data, retainUntilConsumed)
     }
 }

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/paymentflow/PaymentFlowExecutor.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/paymentflow/PaymentFlowExecutor.kt
@@ -7,8 +7,8 @@ import com.getcapacitor.Bridge
 import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.stripe.helper.PaymentSheetHelper
+import com.getcapacitor.community.stripe.models.EventNotifier
 import com.getcapacitor.community.stripe.models.Executor
-import com.google.android.gms.common.util.BiConsumer
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PaymentSheetResult
@@ -20,7 +20,7 @@ internal fun shouldIgnorePaymentOptionResult(hasPaymentOption: Boolean, didCance
 class PaymentFlowExecutor(
     contextSupplier: Supplier<Context>,
     activitySupplier: Supplier<Activity>,
-    notifyListenersFunction: BiConsumer<String, JSObject>,
+    notifyListenersFunction: EventNotifier,
     pluginLogTag: String
 ) : Executor(
     contextSupplier,
@@ -181,15 +181,14 @@ class PaymentFlowExecutor(
         if (shouldIgnorePaymentOptionResult(paymentOption != null, didCancel)) return
 
         val call = bridge.getSavedCall(callbackId)
+
         if (paymentOption != null) {
-            notifyListenersFunction.accept(
-                PaymentFlowEvents.Created.webEventName,
-                JSObject().put("cardNumber", paymentOption.label)
-            )
-            call.resolve(JSObject().put("cardNumber", paymentOption.label))
+            val result = JSObject().put("cardNumber", paymentOption.label)
+            notifyListenersFunction.accept(PaymentFlowEvents.Created.webEventName, result, call == null)
+            call?.resolve(result)
         } else {
-            notifyListenersFunction.accept(PaymentFlowEvents.Canceled.webEventName, emptyObject)
-            call.reject("User close PaymentFlow Sheet")
+            notifyListenersFunction.accept(PaymentFlowEvents.Canceled.webEventName, emptyObject, call == null)
+            call?.reject("User close PaymentFlow Sheet")
         }
     }
 
@@ -201,17 +200,18 @@ class PaymentFlowExecutor(
         val call = bridge.getSavedCall(callbackId)
 
         if (paymentSheetResult is PaymentSheetResult.Canceled) {
-            notifyListenersFunction.accept(PaymentFlowEvents.Canceled.webEventName, emptyObject)
-            call.resolve(JSObject().put("paymentResult", PaymentFlowEvents.Canceled.webEventName))
+            notifyListenersFunction.accept(PaymentFlowEvents.Canceled.webEventName, emptyObject, call == null)
+            call?.resolve(JSObject().put("paymentResult", PaymentFlowEvents.Canceled.webEventName))
         } else if (paymentSheetResult is PaymentSheetResult.Failed) {
             notifyListenersFunction.accept(
                 PaymentFlowEvents.Failed.webEventName,
-                JSObject().put("error", (paymentSheetResult).error.localizedMessage)
+                JSObject().put("error", (paymentSheetResult).error.localizedMessage),
+                call == null
             )
-            call.resolve(JSObject().put("paymentResult", PaymentFlowEvents.Failed.webEventName))
+            call?.resolve(JSObject().put("paymentResult", PaymentFlowEvents.Failed.webEventName))
         } else if (paymentSheetResult is PaymentSheetResult.Completed) {
-            notifyListenersFunction.accept(PaymentFlowEvents.Completed.webEventName, emptyObject)
-            call.resolve(JSObject().put("paymentResult", PaymentFlowEvents.Completed.webEventName))
+            notifyListenersFunction.accept(PaymentFlowEvents.Completed.webEventName, emptyObject, call == null)
+            call?.resolve(JSObject().put("paymentResult", PaymentFlowEvents.Completed.webEventName))
         }
     }
 }

--- a/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/paymentsheet/PaymentSheetExecutor.kt
+++ b/packages/payment/android/src/main/java/com/getcapacitor/community/stripe/paymentsheet/PaymentSheetExecutor.kt
@@ -7,15 +7,15 @@ import com.getcapacitor.Bridge
 import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.stripe.helper.PaymentSheetHelper
+import com.getcapacitor.community.stripe.models.EventNotifier
 import com.getcapacitor.community.stripe.models.Executor
-import com.google.android.gms.common.util.BiConsumer
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 
 class PaymentSheetExecutor(
     contextSupplier: Supplier<Context>,
     activitySupplier: Supplier<Activity>,
-    notifyListenersFunction: BiConsumer<String, JSObject>,
+    notifyListenersFunction: EventNotifier,
     pluginLogTag: String
 ) : Executor(
     contextSupplier,
@@ -144,20 +144,21 @@ class PaymentSheetExecutor(
         val call = bridge.getSavedCall(callbackId)
 
         if (paymentSheetResult is PaymentSheetResult.Canceled) {
-            notifyListenersFunction.accept(PaymentSheetEvents.Canceled.webEventName, emptyObject)
-            call.resolve(JSObject().put("paymentResult", PaymentSheetEvents.Canceled.webEventName))
+            notifyListenersFunction.accept(PaymentSheetEvents.Canceled.webEventName, emptyObject, call == null)
+            call?.resolve(JSObject().put("paymentResult", PaymentSheetEvents.Canceled.webEventName))
         } else if (paymentSheetResult is PaymentSheetResult.Failed) {
             notifyListenersFunction.accept(
                 PaymentSheetEvents.Failed.webEventName,
                 JSObject().put(
                     "message",
                     (paymentSheetResult).error.localizedMessage
-                )
+                ),
+                call == null
             )
-            call.resolve(JSObject().put("paymentResult", PaymentSheetEvents.Failed.webEventName))
+            call?.resolve(JSObject().put("paymentResult", PaymentSheetEvents.Failed.webEventName))
         } else if (paymentSheetResult is PaymentSheetResult.Completed) {
-            notifyListenersFunction.accept(PaymentSheetEvents.Completed.webEventName, emptyObject)
-            call.resolve(JSObject().put("paymentResult", PaymentSheetEvents.Completed.webEventName))
+            notifyListenersFunction.accept(PaymentSheetEvents.Completed.webEventName, emptyObject, call == null)
+            call?.resolve(JSObject().put("paymentResult", PaymentSheetEvents.Completed.webEventName))
         }
     }
 }

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -50,6 +50,17 @@ If you are developing apps for Stripe Android devices (e.g. Stripe Reader S700),
 
 ### Simple collect payment
 
+Register application-level Terminal event listeners once per JavaScript application startup, as early as possible during bootstrap—for example, from `main.ts`, an application initializer, or a singleton service initialized at startup—and before initializing or starting an operation. Keep them registered for the lifetime of their application-level owner:
+
+```typescript
+const paymentStatusListener = await StripeTerminal.addListener(
+  TerminalEventsEnum.PaymentStatusChange,
+  ({ status }) => console.log(status),
+);
+
+// Keep paymentStatusListener and remove it only when its application-level owner is destroyed.
+```
+
 #### Use plugin client
 
 ```typescript

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminal.kt
@@ -15,6 +15,7 @@ import com.getcapacitor.JSArray
 import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.stripe.terminal.helper.TerminalMappers
+import com.getcapacitor.community.stripe.terminal.models.EventNotifier
 import com.getcapacitor.community.stripe.terminal.models.Executor
 import com.google.android.gms.common.util.BiConsumer
 import com.stripe.stripeterminal.Terminal
@@ -61,12 +62,12 @@ import java.util.Objects
 class StripeTerminal(
     contextSupplier: Supplier<Context>,
     activitySupplier: Supplier<Activity>,
-    notifyListenersFunction: BiConsumer<String, JSObject>,
+    eventNotifier: EventNotifier,
     pluginLogTag: String
 ) : Executor(
     contextSupplier,
     activitySupplier,
-    notifyListenersFunction,
+    eventNotifier,
     pluginLogTag,
     "StripeTerminalExecutor"
 ) {
@@ -130,7 +131,9 @@ class StripeTerminal(
         this.tokenProvider = TokenProvider(
             this.contextSupplier,
             call.getString("tokenProviderEndpoint", "")!!,
-            this.notifyListenersFunction
+            BiConsumer { eventName: String, data: JSObject ->
+                notifyListenersFunction.accept(eventName, data)
+            }
         )
         if (!isInitialized()) {
             init(

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/StripeTerminalPlugin.kt
@@ -12,6 +12,7 @@ import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.getcapacitor.annotation.Permission
 import com.getcapacitor.annotation.PermissionCallback
+import com.getcapacitor.community.stripe.terminal.models.EventNotifier
 import com.stripe.stripeterminal.external.models.TerminalException
 
 @RequiresApi(api = Build.VERSION_CODES.S)
@@ -32,7 +33,9 @@ class StripeTerminalPlugin : Plugin() {
     private val implementation = StripeTerminal(
         { this.context },
         { this.activity },
-        { eventName: String?, data: JSObject? -> this.notifyListeners(eventName, data) },
+        EventNotifier { eventName, data, retainUntilConsumed ->
+            this.notifyListeners(eventName, data, retainUntilConsumed)
+        },
         logTag
     )
 

--- a/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/models/Executor.kt
+++ b/packages/terminal/android/src/main/java/com/getcapacitor/community/stripe/terminal/models/Executor.kt
@@ -4,19 +4,29 @@ import android.app.Activity
 import android.content.Context
 import androidx.core.util.Supplier
 import com.getcapacitor.JSObject
-import com.google.android.gms.common.util.BiConsumer
+
+fun interface EventNotifier {
+    fun accept(eventName: String, data: JSObject, retainUntilConsumed: Boolean)
+
+    fun accept(eventName: String, data: JSObject) {
+        accept(eventName, data, false)
+    }
+}
 
 abstract class Executor(
     protected var contextSupplier: Supplier<Context>,
     protected val activitySupplier: Supplier<Activity>,
-    protected var notifyListenersFunction: BiConsumer<String, JSObject>,
+    protected var notifyListenersFunction: EventNotifier,
     pluginLogTag: String,
     executorTag: String
 ) {
     protected val logTag: String = "$pluginLogTag|$executorTag"
 
-    // Eventually we can change the notification directly here!
-    protected fun notifyListeners(eventName: String, data: JSObject) {
-        notifyListenersFunction.accept(eventName, data)
+    protected fun notifyListeners(
+        eventName: String,
+        data: JSObject,
+        retainUntilConsumed: Boolean = false
+    ) {
+        notifyListenersFunction.accept(eventName, data, retainUntilConsumed)
     }
 }


### PR DESCRIPTION
## Context

This is a draft for lifecycle review, especially from maintainers familiar with Capacitor's Android bridge and Activity Result restoration.

The primary production report is [#368](https://github.com/capacitor-community/stripe/issues/368). Android apps repeatedly crashed during Activity resume or app startup because Stripe Identity delivered a verification result after the corresponding `PluginCall` had disappeared from Capacitor's saved-call map:

```text
Failure delivering result ... to activity ...
NullPointerException: ... PluginCall.resolve(...) on a null object reference
```

The reporter confirmed that `bridge.getSavedCall(callbackId)` returned `null`, often within the first few seconds after app startup or Activity resume ([report and stack trace](https://github.com/capacitor-community/stripe/issues/368#issuecomment-2472959781)).

The production evidence in #368 is useful even though the reporter could not reproduce it locally:

- the crash had affected users continuously for months on Identity 5.4.2;
- Crashlytics placed it within the first five seconds of a session;
- the Android stack failed while resuming `MainActivity` and delivering an Activity result;
- the saved-call lookup was confirmed to return `null`; a double invocation of `present()` was raised only as a hypothesis, not established by the report; and
- reports appeared more common on Motorola devices, while most recorded crashes were on Samsung devices.

The requested behavior was therefore to handle a missing call gracefully instead of crashing the whole application during startup or resume.

[PR #426](https://github.com/capacitor-community/stripe/pull/426) previously addressed the Promise dependency by adding `identityVerificationResult` and settling the old `present()` call only when it still exists. That prevents Identity from blindly resolving a missing call, but the result event was still emitted without retention. If the callback arrives before JavaScript has reattached its listener, the app no longer crashes but can still lose the result.

[Issue #445](https://github.com/capacitor-community/stripe/issues/445) demonstrates the same lifecycle mismatch in PaymentSheet with a deterministic reproduction: enable Android's **Don't keep activities**, background the app during 3DS, return, and complete or cancel the sheet. Stripe delivers the result after Activity recreation, but `PaymentSheetExecutor.onPaymentSheetResult` dereferences a missing saved call and crashes.

This is not the same issue as [stripe-android#12809](https://github.com/stripe/stripe-android/issues/12809). That issue documents an intentional FlowController reset callback (`paymentOption = null`, `didCancel = false`) after successful confirmation. The existing plugin guard for that callback remains intact in this change.

## What is happening

The Android flows have two independent lifetimes:

1. The JavaScript method call is stored by Capacitor as an in-memory `PluginCall`, keyed by its callback ID.
2. Stripe's `PaymentSheet`, `FlowController`, `GooglePayLauncher`, and `IdentityVerificationSheet` deliver their UI results through Android Activity Result callbacks.

Normally those lifetimes line up:

```text
JS call -> bridge.saveCall(call) -> Stripe UI -> Stripe callback
        -> bridge.getSavedCall(id) -> resolve/reject Promise
```

After an Activity/Bridge recreation, however, Stripe may still deliver the pending native result to the newly registered callback while the original Bridge's saved-call map—and therefore the original JavaScript Promise—is gone:

```text
old Bridge: JS call -> saved PluginCall -> Activity destroyed
new Bridge: Stripe result callback -> no saved PluginCall
```

The old code assumed `getSavedCall()` always succeeded and dereferenced the result. This caused the original Identity crash in #368 and the PaymentSheet crash in #445. PaymentFlow and Google Pay use the same saved-call pattern, so this change covers those callbacks as well.

The original Promise cannot be reconstructed: its JavaScript execution context is already gone. The recoverable data is the Stripe terminal result delivered to the new plugin instance.

## Approach in this PR

The change is Android-only and keeps the current public API and existing result events.

### PaymentSheet, PaymentFlow, and Google Pay

The plugin continues to use Capacitor's `bridge.saveCall()` and `bridge.getSavedCall()` directly. The shared Android `Executor.kt` change only replaces the two-argument notifier type with `EventNotifier`, so result callbacks can pass Capacitor's `retainUntilConsumed` flag. Each existing result callback continues to own saved-call lookup, event delivery, and Promise settlement:

| State when Stripe returns | Promise | Existing terminal event | Saved call |
| --- | --- | --- | --- |
| Call exists | Resolve/reject exactly as before | Emit normally (`retainUntilConsumed = false`) | Release after settlement |
| Call is missing | Cannot be recovered | Emit the same payload with `retainUntilConsumed = true` | Nothing to release |

This makes the event the recovery path only when the Promise has actually disappeared. Normal calls do not retain an extra event, so adding a listener later does not replay a result that was already handled through the normal path.

Result payloads are preserved, including failure messages. The existing callbacks continue to own event delivery and Promise settlement.

### Identity

`identityVerificationResult` is now emitted with `retainUntilConsumed = true`. Capacitor delivers it immediately when a listener exists; otherwise it retains it for the first listener registration. This completes the event-based recovery direction introduced in #426.

## Data flow after this change

```text
Stripe native result
        |
        v
lookup saved PluginCall by callback ID
        |
        +-- found --> emit normal event --> settle Promise as before
        |
        +-- absent -> retain the same terminal event for listener registration
```

For FlowController, Stripe's post-confirmation reset callback (`null`, `false`) remains ignored. It neither settles the call nor clears the callback ID; the subsequent confirmation result remains the terminal result.

## Scope and limitations

- This handles the case where Stripe delivers a result callback to a live/recreated plugin but the original Capacitor saved call is absent.
- It does not recreate the original JavaScript Promise.
- It does not add disk persistence or claim general recovery after OS process death. Retained listener arguments are in memory; recovery still depends on Stripe/Android delivering the native result to the current plugin instance.
- It does not introduce operation IDs or change the existing restriction around overlapping calls to the same surface.
- Terminal does not use this Activity Result restoration model. Its `Executor.kt` is kept structurally aligned with the other Android packages, but this PR does not change Terminal call settlement or claim Terminal recovery.
- It does not change iOS behavior or public TypeScript APIs.

## Documentation

- The Payment, Identity, and Terminal READMEs now present listener-first result handling during early JavaScript bootstrap as the default integration pattern.
- The demos are intentionally unchanged. Their scenario-scoped listener setup and cleanup should not be mistaken for general Activity Result restoration guidance.

## Questions for the Capacitor team

Before treating this as the long-term plugin pattern, feedback would be useful on:

1. Is `notifyListeners(..., retainUntilConsumed = true)` the intended fallback when an SDK-managed Activity Result reaches a plugin after its saved `PluginCall` has disappeared?
2. Is there a Capacitor lifecycle hook or restoration mechanism intended for Activity Result launchers registered and owned by a third-party SDK, rather than through Capacitor's own activity-call APIs?

## Validation

- `packages/payment/android`: `./gradlew clean build test`
- `packages/identity/android`: `./gradlew clean build test`
- `packages/terminal/android`: `./gradlew clean build test`
- Manager review: approved before the wrappers were narrowed further; launch-failure hardening has since been removed to keep this fix focused.
- Independent acceptance review: accepted.
- External Devin review: approved with no blocking findings.

Completes the retained-event recovery path started for #368 in #426.
Closes #445.
