### PR TITLE
chore: update Stripe native SDKs

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -167,6 +167,8 @@ jobs:
 
   verify-payment-ios:
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -188,6 +190,8 @@ jobs:
 
   verify-identity-ios:
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -209,6 +213,8 @@ jobs:
 
   verify-terminal-ios:
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/demo/angular/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/demo/angular/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios-spm.git",
       "state" : {
-        "revision" : "bf87cb248c4a8bd5176acbf9e10e50a010977ac1",
-        "version" : "25.9.0"
+        "revision" : "1e26d594ede1fdf49c9904be690d4715fb37821f",
+        "version" : "26.6.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-terminal-ios.git",
       "state" : {
-        "revision" : "49c94bcb8f62eca89578938b7d399eb6ad13ebe7",
-        "version" : "5.3.0"
+        "revision" : "f582cccada5ef6d1650b8313e1de49d14120de0b",
+        "version" : "5.7.0"
       }
     }
   ],

--- a/packages/identity/CapacitorCommunityStripeIdentity.podspec
+++ b/packages/identity/CapacitorCommunityStripeIdentity.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripeIdentity', '~> 25.9'
+  s.dependency 'StripeIdentity', '~> 26.6'
   s.swift_version = '5.1'
 end

--- a/packages/identity/Package.swift
+++ b/packages/identity/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/stripe/stripe-ios-spm.git", .upToNextMinor(from: "25.9.0"))
+        .package(url: "https://github.com/stripe/stripe-ios-spm.git", .upToNextMinor(from: "26.6.0"))
     ],
     targets: [
         .target(

--- a/packages/identity/android/build.gradle
+++ b/packages/identity/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
-    identityVersion = project.hasProperty('identityVersion') ? rootProject.ext.identityVersion : '23.1.+'
+    identityVersion = project.hasProperty('identityVersion') ? rootProject.ext.identityVersion : '23.15.+'
 }
 
 buildscript {

--- a/packages/payment/CapacitorCommunityStripe.podspec
+++ b/packages/payment/CapacitorCommunityStripe.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'StripePaymentSheet', '~> 25.9'
-  s.dependency 'StripeApplePay', '~> 25.9'
+  s.dependency 'StripePaymentSheet', '~> 26.6'
+  s.dependency 'StripeApplePay', '~> 26.6'
   s.swift_version = '5.1'
 end

--- a/packages/payment/Package.swift
+++ b/packages/payment/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/stripe/stripe-ios-spm.git", .upToNextMinor(from: "25.9.0"))
+        .package(url: "https://github.com/stripe/stripe-ios-spm.git", .upToNextMinor(from: "26.6.0"))
     ],
     targets: [
         .target(

--- a/packages/payment/android/build.gradle
+++ b/packages/payment/android/build.gradle
@@ -5,7 +5,7 @@ ext {
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
-    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '23.1.+'
+    stripeAndroidVersion = project.hasProperty('stripeAndroidVersion') ? rootProject.ext.stripeAndroidVersion : '23.15.+'
     gsonVersion = project.hasProperty('gsonVersion') ? rootProject.ext.gsonVersion : '2.10.+'
 }
 

--- a/packages/terminal/android/build.gradle
+++ b/packages/terminal/android/build.gradle
@@ -6,9 +6,9 @@ ext {
 
     playServicesWalletVersion = project.hasProperty('playServicesWalletVersion') ? rootProject.ext.playServicesWalletVersion : '19.2.+'
     volleyVersion = project.hasProperty('volleyVersion') ? rootProject.ext.volleyVersion : '1.2.1'
-    stripeterminalTapToPayVersion = project.hasProperty('stripeterminalTapToPayVersion') ? rootProject.ext.stripeterminalTapToPayVersion : '5.3.+'
-    stripeterminalCoreVersion = project.hasProperty('stripeterminalCoreVersion') ? rootProject.ext.stripeterminalCoreVersion : '5.3.+'
-    stripeterminalAppOnDevicesVersion = project.hasProperty('stripeterminalAppOnDevicesVersion') ? rootProject.ext.stripeterminalAppOnDevicesVersion : '5.3.+'
+    stripeterminalTapToPayVersion = project.hasProperty('stripeterminalTapToPayVersion') ? rootProject.ext.stripeterminalTapToPayVersion : '5.7.+'
+    stripeterminalCoreVersion = project.hasProperty('stripeterminalCoreVersion') ? rootProject.ext.stripeterminalCoreVersion : '5.7.+'
+    stripeterminalAppOnDevicesVersion = project.hasProperty('stripeterminalAppOnDevicesVersion') ? rootProject.ext.stripeterminalAppOnDevicesVersion : '5.7.+'
 }
 
 buildscript {


### PR DESCRIPTION
## Summary

Update every Stripe-owned native dependency used by Payment, Identity, and Terminal to the latest release available on 2026-08-12.

| SDK | Before | After |
| --- | --- | --- |
| stripe-android (Payment / Identity) | 23.1.x | 23.15.x |
| stripe-ios (Payment / Identity) | 25.9.x | 26.6.x |
| stripe-terminal-android | 5.3.x | 5.7.x |
| stripe-terminal-ios | 5.3.0 in the demo lockfile | 5.7.0 |

The iOS versions are updated consistently in both Swift Package Manager manifests and CocoaPods podspecs. The demo SPM lockfile is updated to the same versions.

## Why

When the Android Payment and Terminal plugins are installed together, stripe-android 23.1.x detects the Terminal SDK while constructing PaymentSheet and initializes the shared Terminal singleton with the PaymentConfiguration publishable key. The Terminal plugin then sees an already initialized singleton and cannot install its own ConnectionTokenProvider. Connecting a reader consequently fails with:

> This API call cannot be made with a publishable API key.

Stripe fixed the underlying PaymentSheet behavior in stripe-android #13142 by avoiding Terminal initialization when the application does not implement PaymentSheet's Tap to Add callback. Updating to the current SDK resolves that ownership conflict without adding plugin-specific initialization or reflection code.

This PR also brings the other Stripe native dependencies to their current versions so the defaults remain consistent across Payment, Identity, Terminal, Android, SPM, and CocoaPods.

## Impact

- Android applications using Payment and Terminal together allow the Terminal plugin's ConnectionTokenProvider to own Terminal initialization.
- Payment, Identity, and Terminal consumers use the latest Stripe native SDK defaults.
- Applications that override the Gradle version properties remain able to select their own versions.

## Validation

- `packages/payment/android`: `./gradlew clean test`
- `packages/identity/android`: `./gradlew clean test`
- `packages/terminal/android`: `./gradlew clean test`
- Combined Angular Android demo: `./gradlew :app:assembleDebug`
- All three podspecs parse successfully with `pod ipc spec`
- Reproduced the Android failure on a Pixel 8a and verified the upstream-fixed PaymentSheet requests a real Terminal connection token and reaches `terminalConnectedReader`
- iOS application verified on a physical device by the maintainer

Upstream fix: https://github.com/stripe/stripe-android/pull/13142
