### PR TITLE
fix: use supported npm workspace flag in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           done
 
       - name: Build all workspaces
-        run: npm run build -ws --if-present
+        run: npm run build --workspaces --if-present
 
       - name: Commit changes
         run: |
@@ -87,4 +87,3 @@ jobs:
               npm publish --provenance --access public --tag next --workspace "$workspace"
             fi
           done
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "description": "Stripe SDK bindings for Capacitor Applications",
   "scripts": {
     "release": "np --no-tests --no-publish --any-branch",
-    "build": "npm run build -ws --if-present"
+    "build": "npm run build --workspaces --if-present"
   },
   "workspaces": [
     "packages/identity",


### PR DESCRIPTION
## What changed

- Replace npm's deprecated `-ws` shorthand with the documented `--workspaces` flag in the release workflow.
- Apply the same correction to the root `build` script.

## Why

The v8.2.0 release workflow upgrades npm to `latest`, then fails before publishing because the current npm CLI rejects the multi-character single-hyphen flag:

```
-ws is not a valid single-hyphen cli flag. Did you mean --ws?
```

The GitHub Release exists, but none of the three v8.2.0 packages were published to npm.

## Validation

- `npx --yes npm@latest run build --workspaces --if-present`
- All identity, payment, and terminal workspace builds passed.

After this merges, the v8.2.0 tag must be re-fired at the corrected commit because rerunning the existing failed job would use its original workflow revision.
