### PR TITLE
Fix documentation consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ brew install swiftlint
 
 #### `npm run build`
 
-Build the plugin web assets and generate plugin API documentation using [`@capacitor/docgen`](https://github.com/ionic-team/capacitor-docgen).
+Build all plugin packages from the repository root. Each package compiles its web assets and generates its API documentation using `@rdlabo/capacitor-docgen`.
 
 It will compile the TypeScript code from `src/` into ESM JavaScript in `dist/esm/`. These files are used in apps with bundlers when your plugin is imported.
 
@@ -31,13 +31,13 @@ Then, Rollup will bundle the code into a single file at `dist/plugin.js`. This f
 
 #### `npm run verify`
 
-Build and validate the web and native projects.
+Run this from a package directory, or run `npm run verify --workspaces` from the repository root, to build and validate the web and native projects.
 
 This is useful to run in CI to verify that the plugin builds for all platforms.
 
 #### `npm run lint` / `npm run fmt`
 
-Check formatting and code quality, autoformat/autofix if possible.
+Run these from a package directory, or append `--workspaces` when running them from the repository root. They check formatting and code quality, and `fmt` applies automatic fixes where possible.
 
 This template is integrated with ESLint, Prettier, and SwiftLint. Using these tools is completely optional, but the [Capacitor Community](https://github.com/capacitor-community/) strives to have consistent code style and structure for easier cooperation.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use the latest Stripe Android, you need to version these up. To use the lates
 
 ```diff
   ext {
--   minSdkVersio = 24
+-   minSdkVersion = 24
 +   minSdkVersion = 26
     compileSdkVersion = 36
     targetSdkVersion = 36
@@ -122,8 +122,8 @@ Made with [contributors-img](https://contrib.rocks).
 
 ## Demo
 
-- [Demo code is here](https://github.com/capacitor-community/stripe/tree/master/demo). Please check these code before ask at issues.
-- Demo of Web is [hosting here](https://capacitor-community-stripe.netlify.app/).
+- [Demo code is here](https://github.com/capacitor-community/stripe/tree/main/demo). Please check the demo code before opening an issue.
+- The web demo is [hosted here](https://capacitor-community-stripe.netlify.app/).
 
 ### Screenshots
 
@@ -132,7 +132,7 @@ Made with [contributors-img](https://contrib.rocks).
 |              |                     Android                     |                     iOS                     |                     Web                     |
 |:------------:|:-----------------------------------------------:|:-------------------------------------------:|:-------------------------------------------:|
 | PaymentSheet | ![](demo/screenshots/payment-sheet-android.png) | ![](demo/screenshots/payment-sheet-ios.png) | ![](demo/screenshots/payment-sheet-web.png) |
-| PaymentFlow  | ![](demo/screenshots/payment-flow-android.png)  | ![](demo/screenshots/payment-flow-ios.png)  | ![](demo/screenshots/payment-sheet-web.png) |
+| PaymentFlow  | ![](demo/screenshots/payment-flow-android.png)  | ![](demo/screenshots/payment-flow-ios.png)  |            Screenshot unavailable           |
 |   ApplePay   |                  Not supported                  |   ![](demo/screenshots/apple-pay-ios.png)   |                    beta.                    |
 |  GooglePay   |  ![](demo/screenshots/google-pay-android.png)   |                Not supported                |  ![](demo/screenshots/google-pay-web.png)   |
 
@@ -147,6 +147,8 @@ Made with [contributors-img](https://contrib.rocks).
 
 ```bash
 % git clone git@github.com:capacitor-community/stripe.git
-% cd npm install && npm run build
-% cd demo && npm install && npm run cap && npx cap update
+% cd stripe
+% npm install && npm run build
+% cd demo/angular
+% npm install && npm run cap && npx cap update
 ```

--- a/demo/server/README.md
+++ b/demo/server/README.md
@@ -3,6 +3,9 @@
 This Hono API supplies the PaymentIntent, SetupIntent, Identity, and Terminal
 resources used by the demo applications. It runs on Cloudflare Workers.
 
+The deployed demo is available at
+`https://capacitor-stripe-demo-server.bittersweet-barberry.workers.dev/`.
+
 ## Local development
 
 Install dependencies:

--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -11,9 +11,7 @@ npx cap sync
 
 ## How to use
 
-Learn at [the official @capacitor-community/stripe documentation](https://stripe.capacitorjs.jp/).
-
-日本語版をご利用の際は [ja.stripe.capacitorjs.jp](https://ja.stripe.capacitorjs.jp/) をご確認ください。
+The API reference below and the repository's [demo applications](https://github.com/capacitor-community/stripe/tree/main/demo) track the current plugin version.
 
 ### Recommended result handling
 
@@ -726,13 +724,13 @@ addListener(eventName: PaymentSheetEventsEnum.Failed, listenerFunc: (error: stri
 
 #### CreateGooglePayOption
 
-| Prop                            | Type                                              | Description                                  |
-| ------------------------------- | ------------------------------------------------- | -------------------------------------------- |
-| **`paymentIntentClientSecret`** | <code>string</code>                               |                                              |
-| **`paymentSummaryItems`**       | <code>{ label: string; amount: number; }[]</code> | Web only need stripe-pwa-elements &gt; 1.1.0 |
-| **`merchantIdentifier`**        | <code>string</code>                               | Web only need stripe-pwa-elements &gt; 1.1.0 |
-| **`countryCode`**               | <code>string</code>                               | Web only need stripe-pwa-elements &gt; 1.1.0 |
-| **`currency`**                  | <code>string</code>                               | Web only need stripe-pwa-elements &gt; 1.1.0 |
+| Prop                            | Type                                              | Description                                    |
+| ------------------------------- | ------------------------------------------------- | ---------------------------------------------- |
+| **`paymentIntentClientSecret`** | <code>string</code>                               |                                                |
+| **`paymentSummaryItems`**       | <code>{ label: string; amount: number; }[]</code> | Web only. Requires stripe-pwa-elements ^3.0.0. |
+| **`merchantIdentifier`**        | <code>string</code>                               | Web only. Requires stripe-pwa-elements ^3.0.0. |
+| **`countryCode`**               | <code>string</code>                               | Web only. Requires stripe-pwa-elements ^3.0.0. |
+| **`currency`**                  | <code>string</code>                               | Web only. Requires stripe-pwa-elements ^3.0.0. |
 
 
 #### CreatePaymentFlowOption
@@ -917,4 +915,4 @@ Billing details collection options.
 
 ## License
 
-@capacitor-community/stripe is [MIT licensed](./LICENSE).
+@capacitor-community/stripe is [MIT licensed](../../LICENSE).

--- a/packages/payment/src/shared/index.ts
+++ b/packages/payment/src/shared/index.ts
@@ -201,26 +201,22 @@ export interface CreateGooglePayOption {
   paymentIntentClientSecret: string;
 
   /**
-   * Web only
-   * need stripe-pwa-elements > 1.1.0
+   * Web only. Requires stripe-pwa-elements ^3.0.0.
    */
   paymentSummaryItems?: {
     label: string;
     amount: number;
   }[];
   /**
-   * Web only
-   * need stripe-pwa-elements > 1.1.0
+   * Web only. Requires stripe-pwa-elements ^3.0.0.
    */
   merchantIdentifier?: string;
   /**
-   * Web only
-   * need stripe-pwa-elements > 1.1.0
+   * Web only. Requires stripe-pwa-elements ^3.0.0.
    */
   countryCode?: string;
   /**
-   * Web only
-   * need stripe-pwa-elements > 1.1.0
+   * Web only. Requires stripe-pwa-elements ^3.0.0.
    */
   currency?: string;
 }

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -34,12 +34,12 @@ Add permissions to your `android/app/src/main/AndroidManifest.xml` file:
 + <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 ```
 
-And update minSdkVersion to 26 in your `android/app/build.gradle` file:
+And update `minSdkVersion` to 26 in your `android/variables.gradle` file:
 
 ```diff
-  ext {
--    minSdkVersion = 23
-+    minSdkVersion = 26
+ext {
+-   minSdkVersion = 24
++   minSdkVersion = 26
 ```
 
 If you are developing apps for Stripe Android devices (e.g. Stripe Reader S700), follow the Stripe's documentation for the client-side setup.
@@ -64,11 +64,11 @@ const paymentStatusListener = await StripeTerminal.addListener(
 #### Use plugin client
 
 ```typescript
-(async ()=> {
+(async () => {
   /**
    * tokenProviderEndpoint: The URL of your backend to provide a token. Use Post request to get a token.
    */
-  await StripeTerminal.initialize({ tokenProviderEndpoint: 'https://example.com/token', isTest: true })
+  await StripeTerminal.initialize({ tokenProviderEndpoint: 'https://example.com/token', isTest: true });
   const { readers } = await StripeTerminal.discoverReaders({
     type: TerminalConnectTypes.TapToPay,
     locationId: "**************",
@@ -82,21 +82,20 @@ const paymentStatusListener = await StripeTerminal.addListener(
   await StripeTerminal.confirmPaymentIntent();
   // disconnect reader
   await StripeTerminal.disconnectReader();
-});
+})();
 ```
 
 #### set string token
 
 ```typescript
-(async ()=> {
+(async () => {
   // run before StripeTerminal.initialize
-  StripeTerminal.addListener(TerminalEventsEnum.RequestedConnectionToken, async () => {
-    const { token } = (await fetch("https://example.com/token")).json();
-    StripeTerminal.setConnectionToken({ token });
+  await StripeTerminal.addListener(TerminalEventsEnum.RequestedConnectionToken, async () => {
+    const response = await fetch("https://example.com/token", { method: "POST" });
+    const { secret } = await response.json();
+    await StripeTerminal.setConnectionToken({ token: secret });
   });
-});
-(async ()=> {
-  await StripeTerminal.initialize({ isTest: true })
+  await StripeTerminal.initialize({ isTest: true });
   const { readers } = await StripeTerminal.discoverReaders({
     type: TerminalConnectTypes.TapToPay,
     locationId: "**************",
@@ -110,15 +109,15 @@ const paymentStatusListener = await StripeTerminal.addListener(
   await StripeTerminal.confirmPaymentIntent();
   // disconnect reader
   await StripeTerminal.disconnectReader();
-});
-````
+})();
+```
 
 ### Listen device update
 
 The device will **if necessary** automatically start updating itself. It is important to handle them as needed so as not to disrupt business operations.
 
 ```ts
-(async ()=> {
+(async () => {
   StripeTerminal.addListener(TerminalEventsEnum.ReportAvailableUpdate, async ({ update }) => {
     if (window.confirm("Will you update the device?")) {
       await StripeTerminal.installAvailableUpdate();
@@ -136,7 +135,7 @@ The device will **if necessary** automatically start updating itself. It is impo
   StripeTerminal.addListener(TerminalEventsEnum.FinishInstallingUpdate, async ({ update }) => {
     console.log(update);
   });
-});
+})();
 ```
 
 ### Get terminal processing information


### PR DESCRIPTION
## Summary

- align the root README demo instructions, links, screenshots, and Android version example with the repository
- document the actual workspace commands and docgen package in the contributing guide
- correct Terminal setup and connection-token examples to match the current implementation
- regenerate the Payment API documentation from its source JSDoc and point its license link to the root license
- document the deployed Cloudflare Worker URL for the demo server

## Why

Several README sections still described old paths, dependencies, or code examples. The code and package configuration are the source of truth, so these docs now match the current Capacitor 8 packages, demo layout, Terminal API behavior, and Hono Worker deployment.

The Capacitor 7 compatibility guidance remains unchanged.

## Validation

- `npm run build` in `packages/payment`
- `npm run lint -- --no-fix` in `demo/server`
- regenerated `packages/payment/README.md` with docgen
- verified Markdown code fences
- `git diff --check`
- independent senior review approved with no blocking findings
