### PR TITLE
Point READMEs to centralized documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   Capacitor community plugin for native Stripe.
 </p>
 
-Documentation: [https://stripe.capacitorjs.jp/](https://stripe.capacitorjs.jp/)
+Documentation: [Payments](https://docs.rdlabo.dev/projects/capacitor-stripe) · [Identity](https://docs.rdlabo.dev/projects/capacitor-stripe-identity) · [Terminal](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal)
 
 <p align="center">
   <img src="https://img.shields.io/maintenance/yes/2026?style=flat-square" />
@@ -14,11 +14,11 @@ Documentation: [https://stripe.capacitorjs.jp/](https://stripe.capacitorjs.jp/)
 
 ## packages
 
-| package name                         | description | path                                                                                                   |
-|--------------------------------------|-------------|--------------------------------------------------------------------------------------------------------|
-| @capacitor-community/stripe          | Support for non-personal payments using Stripe | [/packages/payment](https://github.com/capacitor-community/stripe/tree/main/packages/payment#readme)   |
-| @capacitor-community/stripe-identity | Supports identity verification using Stripe | [/packages/identity](https://github.com/capacitor-community/stripe/tree/main/packages/identity#readme) |
-| @capacitor-community/stripe-terminal | Support for in-person payments using Stripe  | [/packages/terminal](https://github.com/capacitor-community/stripe/tree/main/packages/terminal#readme) |
+| package name                         | description                                   | source                                                                                                 | documentation                                                                        |
+| ------------------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| @capacitor-community/stripe          | Support for non-personal payments using Stripe | [/packages/payment](https://github.com/capacitor-community/stripe/tree/main/packages/payment#readme)   | [Documentation](https://docs.rdlabo.dev/projects/capacitor-stripe)                   |
+| @capacitor-community/stripe-identity | Supports identity verification using Stripe  | [/packages/identity](https://github.com/capacitor-community/stripe/tree/main/packages/identity#readme) | [Documentation](https://docs.rdlabo.dev/projects/capacitor-stripe-identity)          |
+| @capacitor-community/stripe-terminal | Support for in-person payments using Stripe   | [/packages/terminal](https://github.com/capacitor-community/stripe/tree/main/packages/terminal#readme) | [Documentation](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal)          |
 
 
 ## Hint

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -2,7 +2,7 @@
 
 Stripe Identity SDK bindings for Capacitor Applications.
 
-Documentation: [https://stripe.capacitorjs.jp/stripe-identity](https://stripe.capacitorjs.jp/stripe-identity)
+**Documentation:** [Read the full documentation](https://docs.rdlabo.dev/projects/capacitor-stripe-identity)
 
 ## Install
 

--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -2,7 +2,7 @@
 
 Stripe SDK bindings for Capacitor Applications
 
-Documentation: [https://stripe.capacitorjs.jp/stripe](https://stripe.capacitorjs.jp/stripe)
+**Documentation:** [Read the full documentation](https://docs.rdlabo.dev/projects/capacitor-stripe)
 
 ## Install
 

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -2,7 +2,7 @@
 
 Stripe SDK bindings for Capacitor Applications.
 
-Documentation: [https://stripe.capacitorjs.jp/stripe-terminal](https://stripe.capacitorjs.jp/stripe-terminal)
+**Documentation:** [Read the full documentation](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal)
 
 We have confirmed that it works well in the demo project. Refer to:
 


### PR DESCRIPTION
Points project READMEs to the canonical documentation on docs.rdlabo.dev so users have one maintained source for detailed guidance. Removes README-level sponsorship solicitation where present. Validation: Markdown diffs pass git diff --check.