### PR TITLE
docs: split plugin READMEs into package guides with omit markers

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -2,7 +2,9 @@
 
 Stripe Identity SDK bindings for Capacitor Applications.
 
+<!-- rdlabo-docs-omit -->
 **Documentation:** [Read the full documentation](https://docs.rdlabo.dev/projects/capacitor-stripe-identity)
+<!-- /rdlabo-docs-omit -->
 
 ## Install
 
@@ -30,6 +32,9 @@ see more details on Stripe's native Android SDK page [here](https://stripe.com/d
 
 ## Usage
 
+See [Configuration](./docs/configuration.md) and [Identity Verification Sheet](./docs/identity-verification-sheet.md).
+
+<!-- rdlabo-docs-omit -->
 If you want to implement, we recommend to read https://stripe.com/docs/identity .
 
 ```ts
@@ -258,3 +263,4 @@ Final state reported by the Identity verification flow.
 | **`VerificationResult`** | <code>'identityVerificationResult'</code>            |
 
 </docgen-api>
+<!-- /rdlabo-docs-omit -->

--- a/packages/identity/docs/configuration.md
+++ b/packages/identity/docs/configuration.md
@@ -1,0 +1,45 @@
+---
+title: 'Configuration'
+code: []
+scrollActiveLine: []
+---
+
+Install Stripe Identity and synchronize the native Capacitor projects.
+
+```bash
+npm install @capacitor-community/stripe-identity
+npx cap sync
+```
+
+`@capacitor-community/stripe-identity` v8.2.1 presents Stripe Identity Verification Sheet on iOS, Android, and Web.
+
+| Requirement | Minimum |
+| --- | --- |
+| Capacitor | 8 |
+| iOS | 15.0 |
+| Android `minSdkVersion` | 24 |
+
+## Web configuration
+
+No additional native project steps are necessary. Call `initialize` with a publishable key before `create` and `present` when running on the web. Native platforms resolve `initialize` without using that key.
+
+## iOS configuration
+
+Add `NSCameraUsageDescription` to `Info.plist` with a message explaining why your app needs camera access. See [Stripe's iOS camera authorization guide](https://stripe.com/docs/identity/verify-identity-documents?platform=ios&type=new-integration#set-up-camera-authorization).
+
+The iOS implementation reads the primary app icon from `Info.plist` (`CFBundleIcons` → `CFBundlePrimaryIcon` → `CFBundleIconFiles`) and passes the first file name to Stripe Identity as `brandLogo`. `create` rejects and emits `FailedToLoad` when those keys are missing, with the message `CFBundleIcons or CFBundlePrimaryIcon or CFBundleIconFiles is not found. You should check ios image assets`.
+
+Keep a primary App Icon in the iOS asset catalog so Xcode writes `CFBundleIconFiles`. An app without that icon catalog cannot create the sheet.
+
+## Android configuration
+
+Use a Material Components theme in `android/app/src/main/res/values/styles.xml`:
+
+```diff xml:android/app/src/main/res/values/styles.xml
+- <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
++ <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
+```
+
+Any Material Components parent theme can be used. See [Material Components theming](https://m2.material.io/develop/android/theming/dark/) and [Stripe's Android Material theme guide](https://stripe.com/docs/identity/verify-identity-documents?platform=android&type=new-integration#set-up-material-theme).
+
+The Android implementation uses the application `ic_launcher` mipmap as the Identity Verification Sheet icon. No extra icon configuration is required beyond a standard launcher icon.

--- a/packages/identity/docs/identity-verification-sheet.md
+++ b/packages/identity/docs/identity-verification-sheet.md
@@ -1,0 +1,125 @@
+---
+title: 'Identity Verification Sheet'
+code: ['identity-verification-sheet/example.ts.md']
+scrollActiveLine:
+  [
+    { id: '', activeLine: { ['example.ts']: [1, 1] } },
+    { id: 'listen-for-the-result', activeLine: { ['example.ts']: [5, 18] } },
+    { id: 'obtain-session-credentials', activeLine: { ['example.ts']: [31, 34] } },
+    { id: 'initialize-the-web-platform', activeLine: { ['example.ts']: [27, 31] } },
+    { id: 'create-and-present-the-sheet', activeLine: { ['example.ts']: [34, 42] } },
+    { id: 'handle-failedtoload', activeLine: { ['example.ts']: [18, 27] } },
+    { id: 'handle-verificationresult', activeLine: { ['example.ts']: [5, 18] } },
+    { id: 'errors-and-cancellation', activeLine: { ['example.ts']: [5, 18] } },
+  ]
+---
+
+Stripe Identity verifies identity documents in a native sheet on iOS and Android, and through Stripe.js on the web, while keeping the application code in Capacitor.
+
+The plugin supports iOS, Android, and Web. Native platforms present Stripe's Identity Verification Sheet with `verificationId` and `ephemeralKeySecret`. Web calls `verifyIdentity` with `clientSecret` after `initialize`.
+
+## Listen for the result
+
+Register the result listener once during application startup and before calling `present()`. Android can recreate the Activity and JavaScript runtime while the native sheet is open, so early registration prevents a delivered result from being missed.
+
+Keep the listener for the lifetime of its application-level owner—for example `main.ts`, an application initializer, or a singleton service initialized at startup. Do not remove it immediately after `present()` returns. On Android, `present()` resolves as soon as the sheet is shown; the outcome arrives later through `VerificationResult`.
+
+`Completed`, `Canceled`, and `Failed` are result values delivered on `IdentityVerificationResult.result`. They are not separately supported `addListener` overloads. Register `IdentityVerificationSheetEventsEnum.VerificationResult` and inspect `result`.
+
+!::IdentityVerificationSheetEventsEnum::
+
+The native result handoff is kept in memory. It does not guarantee recovery after operating-system process termination.
+
+## Obtain session credentials
+
+Create a VerificationSession on your backend with the Stripe secret key. Then create an ephemeral key for that session and return only client-safe fields.
+
+The official demo server (`POST /identify`) creates a `document` VerificationSession, creates an ephemeral key with `{ verification_session: session.id }` and Stripe API version `2022-11-15`, and responds with:
+
+| Response field         | Source                              | Plugin `create` option |
+| ---------------------- | ----------------------------------- | ---------------------- |
+| `verificationId`      | `VerificationSession.id`            | `verificationId`       |
+| `ephemeralKeySecret`   | `EphemeralKey.secret`               | `ephemeralKeySecret`   |
+| `clientSecret`         | `VerificationSession.client_secret` | `clientSecret`         |
+
+```ts
+const session = await stripe.identity.verificationSessions.create({
+  type: 'document',
+});
+const ephemeralKey = await stripe.ephemeralKeys.create(
+  { verification_session: session.id },
+  { apiVersion: '2022-11-15' },
+);
+
+return {
+  verificationId: session.id,
+  ephemeralKeySecret: ephemeralKey.secret,
+  clientSecret: session.client_secret,
+};
+```
+
+Keep the Stripe secret key on the server. The Capacitor app should receive only the publishable key (web `initialize`) plus `verificationId`, `ephemeralKeySecret`, and `clientSecret`. Never ship `STRIPE_SECRET_KEY` in the client, native binary, or frontend bundle.
+
+`Completed` on the device means the user finished uploading documents. The VerificationSession then moves to processing. Confirm the official outcome on the server with Identity webhooks such as `identity.verification_session.verified`, `identity.verification_session.requires_input`, `identity.verification_session.processing`, `identity.verification_session.canceled`, and `identity.verification_session.redacted`. See [Handle verification outcomes](https://docs.stripe.com/identity/handle-verification-outcomes).
+
+## Initialize the web platform
+
+`initialize` is required only when running on the web. It loads Stripe.js with the publishable key. Native `initialize` resolves without using that key.
+
+!::initialize::
+
+## Create and present the sheet
+
+Pass the backend fields into `create`, then call `present()`.
+
+- **iOS and Android** require `verificationId` and `ephemeralKeySecret`. Missing either value rejects `create` and emits `FailedToLoad`.
+- **Web** uses `clientSecret` only. Native platforms ignore `clientSecret`. Omit it on native builds if you want; include it when the same code runs on web.
+- Do not import `CreateIdentityVerificationSheetOption` or `InitializeIdentityVerificationSheetOption` from `@capacitor-community/stripe-identity`. Those option types are not re-exported from the package index.
+
+!::create::
+
+!::CreateIdentityVerificationSheetOption::
+
+!::present::
+
+`present()` returns `Promise<void>`. It does not return `IdentityVerificationResult`. Read the outcome from the `VerificationResult` listener.
+
+## Handle FailedToLoad
+
+`FailedToLoad` fires when `create` cannot build the sheet. The `create` promise also rejects with the same text.
+
+Native platforms emit it when `verificationId` or `ephemeralKeySecret` is missing (`Invalid Params. This method require verificationId or ephemeralKeySecret.` on Android; iOS uses the same sentence with a lowercase `this`). iOS also emits it when the primary app icon keys are missing from `Info.plist`.
+
+The listener type is `StripeIdentityError`. iOS delivers `{ message }`. Android currently puts the text on `error` as a string. Handle both the listener and the rejected `create` promise.
+
+Web `create` always emits `Loaded` and does not validate `clientSecret`. Web `present` throws `Stripe is not initialized.` or `clientSecret is not set.` instead of `FailedToLoad`.
+
+!::StripeIdentityError::
+
+## Handle VerificationResult
+
+`IdentityVerificationResult.result` is `IdentityVerificationSheetResultInterface`: `Completed`, `Canceled`, or `Failed`.
+
+| `result`    | Meaning                                                                                                                                |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Completed` | The user submitted documents. Verification is still processing; wait for webhooks.                                                     |
+| `Canceled`  | The user dismissed the sheet. Allow them to try again. On web this is Stripe.js `session_cancelled`.                                   |
+| `Failed`    | The flow failed. Read `error.message` and show it. Native platforms send the localized failure text; web forwards the Stripe.js error. |
+
+`error` is present on `Failed`. Do not register `addListener(IdentityVerificationSheetEventsEnum.Completed)`, `Canceled`, or `Failed`. Those enum members are result values, not supported listener names.
+
+!::IdentityVerificationResult::
+
+!::IdentityVerificationSheetResultInterface::
+
+## Errors and cancellation
+
+Treat cancellation as a user action, not a crash: keep the listener registered and allow another `create` / `present` cycle.
+
+`present()` behavior differs by platform:
+
+- **Android** resolves when the sheet is presented. A later `VerificationResult` (retained in memory until consumed) reports `Completed`, `Canceled`, or `Failed`. A thrown present error rejects the promise.
+- **iOS** waits until the sheet closes, notifies `VerificationResult`, then resolves `present()`.
+- **Web** waits for `verifyIdentity`. Cancellation and failure notify `VerificationResult` and resolve. Missing `initialize` or `clientSecret` rejects.
+
+Do not infer success from `present()` resolving. Always branch on `verification.result`.

--- a/packages/identity/docs/identity-verification-sheet.md
+++ b/packages/identity/docs/identity-verification-sheet.md
@@ -26,7 +26,7 @@ Keep the listener for the lifetime of its application-level owner—for example 
 
 `Completed`, `Canceled`, and `Failed` are result values delivered on `IdentityVerificationResult.result`. They are not separately supported `addListener` overloads. Register `IdentityVerificationSheetEventsEnum.VerificationResult` and inspect `result`.
 
-!::IdentityVerificationSheetEventsEnum::
+<!-- !::IdentityVerificationSheetEventsEnum:: -->
 
 The native result handoff is kept in memory. It does not guarantee recovery after operating-system process termination.
 
@@ -66,7 +66,7 @@ Keep the Stripe secret key on the server. The Capacitor app should receive only 
 
 `initialize` is required only when running on the web. It loads Stripe.js with the publishable key. Native `initialize` resolves without using that key.
 
-!::initialize::
+<!-- !::initialize:: -->
 
 ## Create and present the sheet
 
@@ -76,11 +76,11 @@ Pass the backend fields into `create`, then call `present()`.
 - **Web** uses `clientSecret` only. Native platforms ignore `clientSecret`. Omit it on native builds if you want; include it when the same code runs on web.
 - Do not import `CreateIdentityVerificationSheetOption` or `InitializeIdentityVerificationSheetOption` from `@capacitor-community/stripe-identity`. Those option types are not re-exported from the package index.
 
-!::create::
+<!-- !::create:: -->
 
-!::CreateIdentityVerificationSheetOption::
+<!-- !::CreateIdentityVerificationSheetOption:: -->
 
-!::present::
+<!-- !::present:: -->
 
 `present()` returns `Promise<void>`. It does not return `IdentityVerificationResult`. Read the outcome from the `VerificationResult` listener.
 
@@ -94,7 +94,7 @@ The listener type is `StripeIdentityError`. iOS delivers `{ message }`. Android 
 
 Web `create` always emits `Loaded` and does not validate `clientSecret`. Web `present` throws `Stripe is not initialized.` or `clientSecret is not set.` instead of `FailedToLoad`.
 
-!::StripeIdentityError::
+<!-- !::StripeIdentityError:: -->
 
 ## Handle VerificationResult
 
@@ -108,9 +108,9 @@ Web `create` always emits `Loaded` and does not validate `clientSecret`. Web `pr
 
 `error` is present on `Failed`. Do not register `addListener(IdentityVerificationSheetEventsEnum.Completed)`, `Canceled`, or `Failed`. Those enum members are result values, not supported listener names.
 
-!::IdentityVerificationResult::
+<!-- !::IdentityVerificationResult:: -->
 
-!::IdentityVerificationSheetResultInterface::
+<!-- !::IdentityVerificationSheetResultInterface:: -->
 
 ## Errors and cancellation
 

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -16,7 +16,8 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapacitorCommunityStripeIdentity.podspec"
+    "CapacitorCommunityStripeIdentity.podspec",
+    "docs/"
   ],
   "author": "Masahiko Sakakibara",
   "license": "MIT",

--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -2,7 +2,9 @@
 
 Stripe SDK bindings for Capacitor Applications
 
+<!-- rdlabo-docs-omit -->
 **Documentation:** [Read the full documentation](https://docs.rdlabo.dev/projects/capacitor-stripe)
+<!-- /rdlabo-docs-omit -->
 
 ## Install
 
@@ -11,6 +13,11 @@ npm install @capacitor-community/stripe
 npx cap sync
 ```
 
+## Usage
+
+See [Configuration](./docs/configuration.md) to install the plugin, then [PaymentSheet](./docs/payment-sheet.md), [PaymentFlow](./docs/payment-flow.md), [Apple Pay](./docs/apple-pay.md), and [Google Pay](./docs/google-pay.md).
+
+<!-- rdlabo-docs-omit -->
 ## How to use
 
 The API reference below and the repository's [demo applications](https://github.com/capacitor-community/stripe/tree/main/demo) track the current plugin version.
@@ -1101,3 +1108,4 @@ Final result returned after presenting PaymentSheet.
 ## License
 
 @capacitor-community/stripe is [MIT licensed](../../LICENSE).
+<!-- /rdlabo-docs-omit -->

--- a/packages/payment/docs/angular.md
+++ b/packages/payment/docs/angular.md
@@ -1,0 +1,56 @@
+---
+title: "Angular Quick start"
+code: []
+scrollActiveLine: []
+---
+
+Initialize the plugin once at application startup. Angular 22 applications should use `provideAppInitializer` so initialization runs before Stripe UI is presented.
+
+```ts:src/app/app.config.ts
+import { ApplicationConfig, provideAppInitializer } from '@angular/core';
+import { Stripe } from '@capacitor-community/stripe';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAppInitializer(() =>
+      Stripe.initialize({
+        publishableKey: 'Your Publishable Key',
+      }),
+    ),
+  ],
+};
+```
+
+Register result listeners in the same startup path. See [Event Listeners](./learn/event-listeners.md).
+
+## Web
+
+Install `stripe-pwa-elements` and call `defineCustomElements()` once after Angular bootstraps.
+
+```bash
+npm install stripe-pwa-elements
+```
+
+```ts:src/main.ts
+import { bootstrapApplication } from '@angular/platform-browser';
+import { defineCustomElements } from 'stripe-pwa-elements/loader';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent)
+  .then(() => defineCustomElements(window))
+  .catch((err) => console.log(err));
+```
+
+When you fetch PaymentIntent or SetupIntent secrets from Angular `HttpClient`, use `firstValueFrom`. Do not use the removed `toPromise()` helper.
+
+```ts
+import { firstValueFrom } from 'rxjs';
+
+const { paymentIntent, ephemeralKey, customer } = await firstValueFrom(
+  this.http.post<{
+    paymentIntent: string;
+    ephemeralKey: string;
+    customer: string;
+  }>(environment.api + 'intent', {}),
+);
+```

--- a/packages/payment/docs/apple-pay.md
+++ b/packages/payment/docs/apple-pay.md
@@ -50,7 +50,7 @@ try {
 }
 ```
 
-!::isApplePayAvailable::
+<!-- !::isApplePayAvailable:: -->
 
 ## 2. createApplePay
 
@@ -77,9 +77,9 @@ await Stripe.createApplePay({
 });
 ```
 
-!::createApplePay::
+<!-- !::createApplePay:: -->
 
-!::CreateApplePayOption::
+<!-- !::CreateApplePayOption:: -->
 
 `requiredShippingContactFields` asks Apple Pay for postal address, phone, email, or name. `allowedCountries` rejects shipping countries that are not in the list.
 
@@ -92,9 +92,9 @@ if (result.paymentResult === ApplePayEventsEnum.Completed) {
 }
 ```
 
-!::presentApplePay::
+<!-- !::presentApplePay:: -->
 
-!::ApplePayResultInterface::
+<!-- !::ApplePayResultInterface:: -->
 
 Treat `Canceled` as cancellation and `Failed` as an error.
 
@@ -108,7 +108,7 @@ Stripe.addListener(ApplePayEventsEnum.Completed, () => {
 });
 ```
 
-!::ApplePayEventsEnum::
+<!-- !::ApplePayEventsEnum:: -->
 
 ## 5. updateApplePaySheet
 
@@ -127,17 +127,17 @@ Stripe.addListener(ApplePayEventsEnum.DidSelectShippingContact, async (data) => 
 });
 ```
 
-!::updateApplePaySheet::
+<!-- !::updateApplePaySheet:: -->
 
-!::DidSelectShippingContact::
+<!-- !::DidSelectShippingContact:: -->
 
-!::PaymentSummaryItem::
+<!-- !::PaymentSummaryItem:: -->
 
 `DidCreatePaymentMethod` includes the shipping contact after Apple creates the payment method. Apple does not return the full address until a successful payment.
 
-!::DidCreatePaymentMethod::
+<!-- !::DidCreatePaymentMethod:: -->
 
-!::ShippingContact::
+<!-- !::ShippingContact:: -->
 
 ## Reference
 

--- a/packages/payment/docs/apple-pay.md
+++ b/packages/payment/docs/apple-pay.md
@@ -1,0 +1,145 @@
+---
+title: "ApplePay"
+code: ["/docs/stripe/apple-pay/apple-pay.ts.md"]
+scrollActiveLine: [
+{id: "", activeLine: {}},
+{id: "1.-isapplepayavailable", activeLine: {['apple-pay.ts']: [4, 10]}},
+{id: "2.-createapplepay", activeLine: {['apple-pay.ts']: [15, 31]}},
+{id: "3.-presentapplepay", activeLine: {['apple-pay.ts']: [31, 37]}},
+{id: "4.-addlistener", activeLine: {['apple-pay.ts']: [11, 14]}}
+]
+---
+
+Apple Pay confirms a PaymentIntent in one presentation.
+
+https://stripe.com/docs/apple-pay
+
+[![Image from Gyazo](https://i.gyazo.com/d632147e6d3b33dcc8e28f3ecc898a99.gif)](https://gyazo.com/d632147e6d3b33dcc8e28f3ecc898a99)
+
+## Platform support
+
+| Platform | Apple Pay |
+| --- | --- |
+| iOS | Native `STPApplePayContext` |
+| Android | Not implemented |
+| Web | Payment Request Button (`stripe-pwa-elements`) |
+
+`updateApplePaySheet` and shipping contact updates run on iOS only. Web throws unimplemented for `updateApplePaySheet`. Android rejects `isApplePayAvailable`, `createApplePay`, and `presentApplePay`.
+
+## Prepare settings
+
+- Register an Apple Merchant ID
+- Create an Apple Pay certificate
+- Enable Apple Pay in Xcode
+
+https://stripe.com/docs/apple-pay#merchantid
+
+`createApplePay` `merchantIdentifier` must be the same merchant ID registered in the [Apple Developer](https://developer.apple.com/account/resources/identifiers/add/merchant) account and Xcode. Do not pass `merchantDisplayName` here; that option belongs to PaymentSheet and PaymentFlow.
+
+## 1. isApplePayAvailable
+
+Check the device before you create a request. The promise resolves when Apple Pay is available and rejects otherwise.
+
+```ts
+import { ApplePayEventsEnum, Stripe } from '@capacitor-community/stripe';
+
+try {
+  await Stripe.isApplePayAvailable();
+} catch {
+  return;
+}
+```
+
+!::isApplePayAvailable::
+
+## 2. createApplePay
+
+Fetch a PaymentIntent client secret from your backend. See [Server Integration](./server-integration.md). Then pass `paymentIntentClientSecret`, `paymentSummaryItems`, `merchantIdentifier`, `countryCode`, and `currency`.
+
+```ts
+import { firstValueFrom } from 'rxjs';
+
+const { paymentIntent } = await firstValueFrom(
+  this.http.post<{
+    paymentIntent: string;
+  }>(environment.api + 'intent', {}),
+);
+
+await Stripe.createApplePay({
+  paymentIntentClientSecret: paymentIntent,
+  paymentSummaryItems: [{
+    label: 'Product Name',
+    amount: 1099.00
+  }],
+  merchantIdentifier: 'merchant.com.getcapacitor.stripe',
+  countryCode: 'US',
+  currency: 'USD',
+});
+```
+
+!::createApplePay::
+
+!::CreateApplePayOption::
+
+`requiredShippingContactFields` asks Apple Pay for postal address, phone, email, or name. `allowedCountries` rejects shipping countries that are not in the list.
+
+## 3. presentApplePay
+
+```ts
+const result = await Stripe.presentApplePay();
+if (result.paymentResult === ApplePayEventsEnum.Completed) {
+  // Update UI only. Confirm the Intent with a webhook before fulfilling.
+}
+```
+
+!::presentApplePay::
+
+!::ApplePayResultInterface::
+
+Treat `Canceled` as cancellation and `Failed` as an error.
+
+## 4. addListener
+
+Register listeners at application startup. See [Event Listeners](./learn/event-listeners.md).
+
+```ts
+Stripe.addListener(ApplePayEventsEnum.Completed, () => {
+  console.log('ApplePayEventsEnum.Completed');
+});
+```
+
+!::ApplePayEventsEnum::
+
+## 5. updateApplePaySheet
+
+On iOS, `DidSelectShippingContact` includes `contact` and `updateId`. Recalculate totals and call `updateApplePaySheet` with that `updateId`. If JavaScript does not respond, the native sheet falls back to the original summary items after 25 seconds.
+
+```ts
+Stripe.addListener(ApplePayEventsEnum.DidSelectShippingContact, async (data) => {
+  await Stripe.updateApplePaySheet({
+    updateId: data.updateId,
+    paymentSummaryItems: [
+      { label: 'Product Name', amount: 1099.00 },
+      { label: 'Shipping', amount: 500.00 },
+      { label: 'Total', amount: 1599.00 },
+    ],
+  });
+});
+```
+
+!::updateApplePaySheet::
+
+!::DidSelectShippingContact::
+
+!::PaymentSummaryItem::
+
+`DidCreatePaymentMethod` includes the shipping contact after Apple creates the payment method. Apple does not return the full address until a successful payment.
+
+!::DidCreatePaymentMethod::
+
+!::ShippingContact::
+
+## Reference
+
+- [Apple Pay (iOS)](https://stripe.com/docs/apple-pay)
+- [Merchant name on the Apple Pay sheet](https://github.com/capacitor-community/stripe/issues/115)

--- a/packages/payment/docs/configuration.md
+++ b/packages/payment/docs/configuration.md
@@ -1,0 +1,53 @@
+---
+title: "Configuration platform"
+code: []
+scrollActiveLine: []
+---
+
+Install `@capacitor-community/stripe` and synchronize the native projects. Capacitor 8 registers the plugin automatically, so you do not edit `MainActivity` or add a manual `registerPlugin` call.
+
+```bash
+npm install @capacitor-community/stripe
+npx cap sync
+```
+
+The plugin depends on Capacitor 8 or later. Web also needs the `stripe-pwa-elements` peer dependency. Keep the Stripe secret key on your server only. See [Server Integration](./server-integration.md).
+
+| Requirement | Minimum |
+| --- | --- |
+| Capacitor | 8 |
+| iOS | 15.0 |
+| Android `minSdkVersion` | 24 |
+
+## Android configuration
+
+No extra Gradle or `MainActivity` registration is required for the plugin itself.
+
+Google Pay on Android must be configured with application metadata before the plugin loads. Follow [Google Pay](./google-pay.md).
+
+Optional Stripe Connect: if Android Google Pay should run against a connected account, add `com.getcapacitor.community.stripe.stripe_account` metadata. Native and web PaymentSheet, PaymentFlow, Apple Pay, and Google Pay also accept `stripeAccount` on `initialize`.
+
+## iOS configuration
+
+Add `NSCameraUsageDescription` so PaymentSheet can scan cards:
+
+```diff plist:ios/App/App/Info.plist
+  	<key>UIViewControllerBasedStatusBarAppearance</key>
+	  <true/>
+
++   <key>NSCameraUsageDescription</key>
++   <string>Need camera access for read credit card.</string>
+  </dict>
+```
+
+The plugin loads automatically on iOS. Apple Pay also needs an Apple Merchant ID and certificate. Follow [Apple Pay](./apple-pay.md).
+
+For 3D Secure redirects, set `returnURL` when you create PaymentSheet or PaymentFlow, then call `handleURLCallback` from your app URL handler. See [Initialize](./initialize.md).
+
+## Web configuration
+
+Install `stripe-pwa-elements` and call `defineCustomElements()` once during bootstrap. Serve the app over HTTPS in development and production.
+
+- [Vanilla JS Quick start](./vanilla-js.md)
+- [Angular Quick start](./angular.md)
+- [React Quick start](./react.md)

--- a/packages/payment/docs/google-pay.md
+++ b/packages/payment/docs/google-pay.md
@@ -153,7 +153,7 @@ try {
 }
 ```
 
-!::isGooglePayAvailable::
+<!-- !::isGooglePayAvailable:: -->
 
 ## 2. createGooglePay
 
@@ -182,9 +182,9 @@ await Stripe.createGooglePay({
 });
 ```
 
-!::createGooglePay::
+<!-- !::createGooglePay:: -->
 
-!::CreateGooglePayOption::
+<!-- !::CreateGooglePayOption:: -->
 
 :::message
 `paymentSummaryItems`, `merchantIdentifier`, `countryCode`, and `currency` are required on web. Android uses the metadata country and merchant name instead.
@@ -201,9 +201,9 @@ if (result.paymentResult === GooglePayEventsEnum.Completed) {
 }
 ```
 
-!::presentGooglePay::
+<!-- !::presentGooglePay:: -->
 
-!::GooglePayResultInterface::
+<!-- !::GooglePayResultInterface:: -->
 
 Treat `Canceled` as cancellation and `Failed` as an error. Prefer result listeners after Android Activity recreation. See [Event Listeners](./learn/event-listeners.md).
 
@@ -215,7 +215,7 @@ Stripe.addListener(GooglePayEventsEnum.Completed, () => {
 });
 ```
 
-!::GooglePayEventsEnum::
+<!-- !::GooglePayEventsEnum:: -->
 
 ## Reference
 

--- a/packages/payment/docs/google-pay.md
+++ b/packages/payment/docs/google-pay.md
@@ -1,0 +1,223 @@
+---
+title: "Google Pay"
+code: [
+  "/docs/stripe/google-pay/strings.xml.md",
+  "/docs/stripe/google-pay/android-manifest.xml.md",
+  "/docs/stripe/google-pay/google-pay.ts.md"
+]
+scrollActiveLine: [
+  {id: "", activeLine: {}},
+  {id: "strings.xml", activeLine: {['strings.xml']: [7, 14]}},
+  {id: "androidmanifest.xml", activeLine: {['AndroidManifest.xml']: [36, 60]}},
+  {id: "1.-isgooglepayavailable", activeLine: {['google-pay.ts']: [4, 10]}},
+  {id: "2.-creategooglepay", activeLine: {['google-pay.ts']: [15, 33]}},
+  {id: "3.-presentgooglepay", activeLine: {['google-pay.ts']: [33, 39]}},
+  {id: "4.-addlistener", activeLine: {['google-pay.ts']: [11, 14]}}
+]
+---
+
+Google Pay confirms a PaymentIntent in one presentation. The Android implementation also accepts a SetupIntent; the web implementation does not.
+
+https://stripe.com/docs/google-pay
+
+On web, Google Pay uses the Payment Request Button. Serve the app over HTTPS in development and production.
+
+https://stripe.com/docs/stripe-js/elements/payment-request-button?platform=html-js-testing-google-pay#html-js-prerequisites
+
+## Platform support
+
+| Platform | Google Pay |
+| --- | --- |
+| Android | Native `GooglePayLauncher` (requires app metadata) |
+| iOS | Not implemented |
+| Web | Payment Request Button (`stripe-pwa-elements`) |
+
+iOS rejects `isGooglePayAvailable`, `createGooglePay`, and `presentGooglePay`. Android reads Google Pay configuration from metadata when the plugin loads, so `initialize` alone is not enough on Android.
+
+## Prepare settings
+
+### strings.xml
+
+In `android/app/src/main/res/values/strings.xml` add:
+
+- `publishable_key` (Stripe publishable key)
+- `enable_google_pay`
+- `country_code`
+- `merchant_display_name`
+- `google_pay_is_testing`
+
+```xml
+<string name="publishable_key">Your Publishable Key</string>
+<bool name="enable_google_pay">true</bool>
+<string name="country_code">US</string>
+<string name="merchant_display_name">Widget Store</string>
+<bool name="google_pay_is_testing">true</bool>
+```
+
+Optional Stripe Connect on Android Google Pay:
+
+```xml
+<string name="stripe_account">acct_xxxxxxxxxxxxx</string>
+```
+
+### AndroidManifest.xml
+
+In `android/app/src/main/AndroidManifest.xml`, add the following under `manifest > application`:
+
+```xml
+<meta-data
+  android:name="com.google.android.gms.wallet.api.enabled"
+  android:value="true" />
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.enable_google_pay"
+  android:value="@bool/enable_google_pay"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.publishable_key"
+  android:value="@string/publishable_key"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.country_code"
+  android:value="@string/country_code"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.merchant_display_name"
+  android:value="@string/merchant_display_name"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.google_pay_is_testing"
+  android:value="@bool/google_pay_is_testing"/>
+```
+
+Optional connected account:
+
+```xml
+<meta-data
+  android:name="com.getcapacitor.community.stripe.stripe_account"
+  android:value="@string/stripe_account"/>
+```
+
+#### Optional1: If you get user information, set these:
+
+```xml
+<bool name="email_address_required">true</bool>
+<bool name="phone_number_required">true</bool>
+<bool name="billing_address_required">true</bool>
+<string name="billing_address_format">Full</string>
+```
+
+```xml
+<meta-data
+  android:name="com.getcapacitor.community.stripe.email_address_required"
+  android:value="@bool/email_address_required"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.phone_number_required"
+  android:value="@bool/phone_number_required"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.billing_address_required"
+  android:value="@bool/billing_address_required"/>
+
+<meta-data
+  android:name="com.getcapacitor.community.stripe.billing_address_format"
+  android:value="@string/billing_address_format"/>
+```
+
+#### Optional2: If you don't require existing payment method at Google Pay:
+
+If false, Google Pay is considered ready even if the customer's Google Pay wallet does not have existing payment methods. Defaults to true.
+
+```xml
+<bool name="google_pay_existing_payment_method_required">false</bool>
+```
+
+```xml
+<meta-data
+  android:name="com.getcapacitor.community.stripe.google_pay_existing_payment_method_required"
+  android:value="@bool/google_pay_existing_payment_method_required"/>
+```
+
+## 1. isGooglePayAvailable
+
+The promise resolves when Google Pay is ready and rejects otherwise.
+
+```ts
+import { GooglePayEventsEnum, Stripe } from '@capacitor-community/stripe';
+
+try {
+  await Stripe.isGooglePayAvailable();
+} catch {
+  return;
+}
+```
+
+!::isGooglePayAvailable::
+
+## 2. createGooglePay
+
+Fetch a PaymentIntent client secret from your backend. On Android, you may instead pass a SetupIntent client secret. See [Server Integration](./server-integration.md). The option is named `paymentIntentClientSecret` for both Intent types. Web also needs `paymentSummaryItems`, `merchantIdentifier`, `countryCode`, and `currency`.
+
+```ts
+import { firstValueFrom } from 'rxjs';
+
+const { paymentIntent } = await firstValueFrom(
+  this.http.post<{
+    paymentIntent: string;
+  }>(environment.api + 'intent', {}),
+);
+
+await Stripe.createGooglePay({
+  paymentIntentClientSecret: paymentIntent,
+
+  // Web only. Google Pay on Android App doesn't need
+  paymentSummaryItems: [{
+    label: 'Product Name',
+    amount: 1099.00
+  }],
+  merchantIdentifier: 'merchant.com.getcapacitor.stripe',
+  countryCode: 'US',
+  currency: 'USD',
+});
+```
+
+!::createGooglePay::
+
+!::CreateGooglePayOption::
+
+:::message
+`paymentSummaryItems`, `merchantIdentifier`, `countryCode`, and `currency` are required on web. Android uses the metadata country and merchant name instead.
+:::
+
+A SetupIntent client secret starts with `seti_`. Android detects that prefix and uses `presentForSetupIntent` with `currency` from the create options (default `USD`). Do not pass a SetupIntent on web: the web implementation confirms with `confirmCardPayment`.
+
+## 3. presentGooglePay
+
+```ts
+const result = await Stripe.presentGooglePay();
+if (result.paymentResult === GooglePayEventsEnum.Completed) {
+  // Update UI only. Confirm the Intent with a webhook before fulfilling.
+}
+```
+
+!::presentGooglePay::
+
+!::GooglePayResultInterface::
+
+Treat `Canceled` as cancellation and `Failed` as an error. Prefer result listeners after Android Activity recreation. See [Event Listeners](./learn/event-listeners.md).
+
+## 4. addListener
+
+```ts
+Stripe.addListener(GooglePayEventsEnum.Completed, () => {
+  console.log('GooglePayEventsEnum.Completed');
+});
+```
+
+!::GooglePayEventsEnum::
+
+## Reference
+
+- [Google Pay (Android)](https://stripe.com/docs/google-pay)
+- [Google Pay (Web)](https://stripe.com/docs/stripe-js/elements/payment-request-button?platform=html-js-testing-google-pay#html-js-prerequisites)

--- a/packages/payment/docs/initialize.md
+++ b/packages/payment/docs/initialize.md
@@ -16,9 +16,9 @@ export async function initialize(): Promise<void> {
 }
 ```
 
-!::initialize::
+<!-- !::initialize:: -->
 
-!::StripeInitializationOptions::
+<!-- !::StripeInitializationOptions:: -->
 
 Create a publishable key in the [Stripe Dashboard](https://dashboard.stripe.com/register). Never ship the secret key to the client.
 
@@ -49,9 +49,9 @@ await Stripe.createPaymentSheet({
 await Stripe.handleURLCallback({ url });
 ```
 
-!::handleURLCallback::
+<!-- !::handleURLCallback:: -->
 
-!::StripeURLHandlingOptions::
+<!-- !::StripeURLHandlingOptions:: -->
 
 The method is not implemented on Android or web. If Stripe did not handle the URL, the promise rejects and you should continue with your normal deep-link handling.
 

--- a/packages/payment/docs/initialize.md
+++ b/packages/payment/docs/initialize.md
@@ -1,0 +1,84 @@
+---
+title: "Initialize to your project"
+code: []
+scrollActiveLine: []
+---
+
+Import `Stripe` and call `initialize` with a [publishable key](https://dashboard.stripe.com/apikeys). Do this once per JavaScript runtime, before you create or present any payment UI.
+
+```ts
+import { Stripe } from '@capacitor-community/stripe';
+
+export async function initialize(): Promise<void> {
+  await Stripe.initialize({
+    publishableKey: 'Your Publishable Key',
+  });
+}
+```
+
+!::initialize::
+
+!::StripeInitializationOptions::
+
+Create a publishable key in the [Stripe Dashboard](https://dashboard.stripe.com/register). Never ship the secret key to the client.
+
+## Stripe Connect
+
+Set optional `stripeAccount` to make plugin API calls for a [connected account](https://stripe.com/docs/connect/authentication).
+
+```ts
+await Stripe.initialize({
+  publishableKey: 'Your Publishable Key',
+  stripeAccount: 'acct_xxxxxxxxxxxxx',
+});
+```
+
+On Android, Google Pay can also read `com.getcapacitor.community.stripe.stripe_account` from application metadata. See [Google Pay](./google-pay.md).
+
+## handleURLCallback
+
+`handleURLCallback` is iOS only. Use it with `returnURL` on PaymentSheet or PaymentFlow so Stripe can finish [3D Secure](https://stripe.com/docs/payments/3d-secure#return-url) after the customer returns from the bank page.
+
+```ts
+await Stripe.createPaymentSheet({
+  paymentIntentClientSecret,
+  returnURL: 'your-app://stripe-redirect',
+});
+
+// Call from the iOS URL open handler with the returned URL.
+await Stripe.handleURLCallback({ url });
+```
+
+!::handleURLCallback::
+
+!::StripeURLHandlingOptions::
+
+The method is not implemented on Android or web. If Stripe did not handle the URL, the promise rejects and you should continue with your normal deep-link handling.
+
+## Example
+
+### Angular
+
+Initialize from the root component. See [Angular](./angular.md).
+
+```ts:src/app/app.component.ts
+import { Component } from '@angular/core';
+import { Stripe } from '@capacitor-community/stripe';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.scss'],
+})
+export class AppComponent {
+  constructor() {
+    void Stripe.initialize({
+      publishableKey: 'Your Publishable Key',
+    });
+  }
+}
+```
+
+### React
+
+`CapacitorStripeProvider` initializes the plugin for you. See [React](./react.md).

--- a/packages/payment/docs/learn/event-listeners.md
+++ b/packages/payment/docs/learn/event-listeners.md
@@ -1,0 +1,79 @@
+---
+title: "Event Listeners"
+code: []
+scrollActiveLine: []
+---
+
+Use result events as the default result path. Register application-level result listeners once per JavaScript application startup, as early as possible during bootstrap—for example from `main.ts`, an application initializer, or a singleton service initialized at startup—and before presenting Stripe UI.
+
+```ts
+import {
+  ApplePayEventsEnum,
+  GooglePayEventsEnum,
+  PaymentFlowEventsEnum,
+  PaymentSheetEventsEnum,
+  Stripe,
+} from '@capacitor-community/stripe';
+
+await Promise.all([
+  Stripe.addListener(PaymentSheetEventsEnum.Completed, () => handleCompleted()),
+  Stripe.addListener(PaymentSheetEventsEnum.Canceled, () => handleCanceled()),
+  Stripe.addListener(PaymentSheetEventsEnum.Failed, (error) => handleFailed(error)),
+]);
+```
+
+!::addListener::
+
+!::PluginListenerHandle::
+
+## Android activity recreation
+
+This is especially important on Android, where the Activity and JavaScript runtime can be recreated while Stripe's UI is open. The new JavaScript runtime must register its listeners during bootstrap.
+
+The original JavaScript Promise and Capacitor `PluginCall` cannot be restored. If Stripe delivers the native result after recreation, the plugin retains the corresponding result event until a listener is available. This applies to the `Completed`, `Canceled`, and `Failed` events for PaymentSheet, PaymentFlow, and Google Pay, and to the `Created` event for PaymentFlow.
+
+If the original call still exists, behavior is unchanged: the Promise is settled normally and the event is delivered without being retained. This fallback is an in-memory handoff of a native result; it is not persistent storage and does not guarantee recovery after OS process death.
+
+Keep application-level result listeners registered for the lifetime of the JavaScript runtime. Do not add them in a button handler and remove them when a page unmounts if you still need the payment result after Android recreation.
+
+## PaymentSheet events
+
+!::PaymentSheetEventsEnum::
+
+Typical PaymentSheet flow:
+
+1. Register result listeners at startup.
+2. Call `createPaymentSheet()`.
+3. Wait for `Loaded`, or handle `FailedToLoad`.
+4. Call `presentPaymentSheet()`.
+5. Receive one of `Completed`, `Canceled`, or `Failed`.
+
+`Canceled` means the customer dismissed the sheet. Treat it as cancellation, not as a thrown error. `Failed` and `FailedToLoad` include an error string. Do not fulfill an order from the client event alone; confirm the PaymentIntent or SetupIntent with a [webhook](./server-integration.md).
+
+## PaymentFlow events
+
+!::PaymentFlowEventsEnum::
+
+Typical PaymentFlow flow:
+
+1. Register result listeners at startup.
+2. Call `createPaymentFlow()`.
+3. Wait for `Loaded`, or handle `FailedToLoad`.
+4. Call `presentPaymentFlow()`.
+5. Receive `Opened`, then `Created` with `{ cardNumber }`, or `Canceled`.
+6. Call `confirmPaymentFlow()`.
+7. Receive one of `Completed`, `Canceled`, or `Failed`.
+
+## Apple Pay events
+
+!::ApplePayEventsEnum::
+
+`DidSelectShippingContact` includes `contact` and `updateId`. On iOS, call `updateApplePaySheet` with that `updateId` and updated `paymentSummaryItems`. If JavaScript does not respond, the native sheet falls back to the original items after 25 seconds. `updateApplePaySheet` is not implemented on Android or web.
+
+`DidCreatePaymentMethod` includes the shipping `contact`. Apple does not return the full address until a successful payment.
+
+## Google Pay events
+
+!::GooglePayEventsEnum::
+
+Google Pay is available on Android and web. It is not implemented on iOS.

--- a/packages/payment/docs/learn/event-listeners.md
+++ b/packages/payment/docs/learn/event-listeners.md
@@ -22,9 +22,9 @@ await Promise.all([
 ]);
 ```
 
-!::addListener::
+<!-- !::addListener:: -->
 
-!::PluginListenerHandle::
+<!-- !::PluginListenerHandle:: -->
 
 ## Android activity recreation
 
@@ -38,7 +38,7 @@ Keep application-level result listeners registered for the lifetime of the JavaS
 
 ## PaymentSheet events
 
-!::PaymentSheetEventsEnum::
+<!-- !::PaymentSheetEventsEnum:: -->
 
 Typical PaymentSheet flow:
 
@@ -52,7 +52,7 @@ Typical PaymentSheet flow:
 
 ## PaymentFlow events
 
-!::PaymentFlowEventsEnum::
+<!-- !::PaymentFlowEventsEnum:: -->
 
 Typical PaymentFlow flow:
 
@@ -66,7 +66,7 @@ Typical PaymentFlow flow:
 
 ## Apple Pay events
 
-!::ApplePayEventsEnum::
+<!-- !::ApplePayEventsEnum:: -->
 
 `DidSelectShippingContact` includes `contact` and `updateId`. On iOS, call `updateApplePaySheet` with that `updateId` and updated `paymentSummaryItems`. If JavaScript does not respond, the native sheet falls back to the original items after 25 seconds. `updateApplePaySheet` is not implemented on Android or web.
 
@@ -74,6 +74,6 @@ Typical PaymentFlow flow:
 
 ## Google Pay events
 
-!::GooglePayEventsEnum::
+<!-- !::GooglePayEventsEnum:: -->
 
 Google Pay is available on Android and web. It is not implemented on iOS.

--- a/packages/payment/docs/payment-flow.md
+++ b/packages/payment/docs/payment-flow.md
@@ -1,0 +1,111 @@
+---
+title: "PaymentFlow"
+code: ["/docs/stripe/payment-flow/payment-flow.ts.md"]
+scrollActiveLine: [
+  {id: "", activeLine: {}},
+  {id: "1.-createpaymentflow", activeLine: {['payment-flow.ts']: [9, 23]}},
+  {id: "2.-presentpaymentflow", activeLine: {['payment-flow.ts']: [23, 27]}},
+  {id: "3.-confirmpaymentflow", activeLine: {['payment-flow.ts']: [27, 33]}},
+  {id: "4.-addlistener", activeLine: {['payment-flow.ts']: [4, 8]}}
+]
+---
+
+PaymentFlow splits collection and confirmation. `presentPaymentFlow` collects the payment method and returns a pending card. `confirmPaymentFlow` confirms the Intent later, usually after a review screen.
+
+[![Image from Gyazo](https://i.gyazo.com/736450bb2e267eab0bba578e366fcba5.gif)](https://gyazo.com/736450bb2e267eab0bba578e366fcba5)
+
+Use a [PaymentIntent](https://stripe.com/docs/payments/payment-intents) or a [SetupIntent](https://stripe.com/docs/payments/save-and-reuse?platform=web). Create those objects on your server. See [Server Integration](./server-integration.md).
+
+## Platform support
+
+| Platform | PaymentFlow |
+| --- | --- |
+| iOS | Native PaymentSheet.FlowController |
+| Android | Native PaymentSheet.FlowController |
+| Web | `stripe-pwa-elements` card modal |
+
+Web supports `paymentIntentClientSecret` or `setupIntentClientSecret`, plus optional `withZipCode`. Native-only options such as `defaultBillingDetails`, `shippingDetails`, `billingDetailsCollectionConfiguration`, `enableApplePay`, `enableGooglePay`, `style`, and `returnURL` are ignored on web.
+
+## 1. createPaymentFlow
+
+Fetch client-safe secrets from your backend, then call `createPaymentFlow`. Provide **either** `paymentIntentClientSecret` **or** `setupIntentClientSecret`. `customerId` and `customerEphemeralKeySecret` are optional together. If you set `customerId`, you must also set `customerEphemeralKeySecret`.
+
+```ts
+import { firstValueFrom } from 'rxjs';
+import { PaymentFlowEventsEnum, Stripe } from '@capacitor-community/stripe';
+
+const { paymentIntent, ephemeralKey, customer } = await firstValueFrom(
+  this.http.post<{
+    paymentIntent: string;
+    ephemeralKey: string;
+    customer: string;
+  }>(environment.api + 'intent', {}),
+);
+
+await Stripe.createPaymentFlow({
+  paymentIntentClientSecret: paymentIntent,
+  customerEphemeralKeySecret: ephemeralKey,
+  customerId: customer,
+  merchantDisplayName: 'rdlabo',
+});
+```
+
+!::createPaymentFlow::
+
+!::CreatePaymentFlowOption::
+
+## 2. presentPaymentFlow
+
+Call `presentPaymentFlow` only after `createPaymentFlow` succeeds. The returned `cardNumber` is a masked value. The Intent is not confirmed yet.
+
+```ts
+const presentResult = await Stripe.presentPaymentFlow();
+console.log(presentResult); // { cardNumber: "●●●● ●●●● ●●●● ****" }
+```
+
+!::presentPaymentFlow::
+
+If the customer cancels, the promise rejects or the `Canceled` event fires. Do not call `confirmPaymentFlow` until `Created` or a successful `presentPaymentFlow` result.
+
+## 3. confirmPaymentFlow
+
+```ts
+const confirmResult = await Stripe.confirmPaymentFlow();
+if (confirmResult.paymentResult === PaymentFlowEventsEnum.Completed) {
+  // Update UI only. Confirm the Intent with a webhook before fulfilling.
+}
+```
+
+!::confirmPaymentFlow::
+
+!::PaymentFlowResultInterface::
+
+Treat `Canceled` as cancellation and `Failed` as an error. Neither result authorizes fulfillment by itself.
+
+## 4. addListener
+
+Register result listeners once at application startup. Prefer events over the Promise after Android Activity recreation, including the `Created` event. See [Event Listeners](./learn/event-listeners.md).
+
+```ts
+await Promise.all([
+  Stripe.addListener(PaymentFlowEventsEnum.Created, (info) => {
+    console.log(info.cardNumber);
+  }),
+  Stripe.addListener(PaymentFlowEventsEnum.Completed, () => {
+    console.log('PaymentFlowEventsEnum.Completed');
+  }),
+  Stripe.addListener(PaymentFlowEventsEnum.Canceled, () => {
+    console.log('PaymentFlowEventsEnum.Canceled');
+  }),
+  Stripe.addListener(PaymentFlowEventsEnum.Failed, (error) => {
+    console.log('PaymentFlowEventsEnum.Failed', error);
+  }),
+]);
+```
+
+!::PaymentFlowEventsEnum::
+
+## Reference
+
+- [Complete the payment in your own UI (iOS)](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-flowcontroller)
+- [Complete the payment in your own UI (Android)](https://stripe.com/docs/payments/accept-a-payment?platform=android&ui=payment-sheet#android-flowcontroller)

--- a/packages/payment/docs/payment-flow.md
+++ b/packages/payment/docs/payment-flow.md
@@ -50,9 +50,9 @@ await Stripe.createPaymentFlow({
 });
 ```
 
-!::createPaymentFlow::
+<!-- !::createPaymentFlow:: -->
 
-!::CreatePaymentFlowOption::
+<!-- !::CreatePaymentFlowOption:: -->
 
 ## 2. presentPaymentFlow
 
@@ -63,7 +63,7 @@ const presentResult = await Stripe.presentPaymentFlow();
 console.log(presentResult); // { cardNumber: "●●●● ●●●● ●●●● ****" }
 ```
 
-!::presentPaymentFlow::
+<!-- !::presentPaymentFlow:: -->
 
 If the customer cancels, the promise rejects or the `Canceled` event fires. Do not call `confirmPaymentFlow` until `Created` or a successful `presentPaymentFlow` result.
 
@@ -76,9 +76,9 @@ if (confirmResult.paymentResult === PaymentFlowEventsEnum.Completed) {
 }
 ```
 
-!::confirmPaymentFlow::
+<!-- !::confirmPaymentFlow:: -->
 
-!::PaymentFlowResultInterface::
+<!-- !::PaymentFlowResultInterface:: -->
 
 Treat `Canceled` as cancellation and `Failed` as an error. Neither result authorizes fulfillment by itself.
 
@@ -103,7 +103,7 @@ await Promise.all([
 ]);
 ```
 
-!::PaymentFlowEventsEnum::
+<!-- !::PaymentFlowEventsEnum:: -->
 
 ## Reference
 

--- a/packages/payment/docs/payment-sheet.md
+++ b/packages/payment/docs/payment-sheet.md
@@ -51,9 +51,9 @@ await Stripe.createPaymentSheet({
 });
 ```
 
-!::createPaymentSheet::
+<!-- !::createPaymentSheet:: -->
 
-!::CreatePaymentSheetOption::
+<!-- !::CreatePaymentSheetOption:: -->
 
 Optional native settings include `style` (`alwaysLight` or `alwaysDark`, iOS only), `enableApplePay` with `applePayMerchantId`, `enableGooglePay`, `returnURL` for 3D Secure on iOS, and billing collection options. `withZipCode` is web only. `currencyCode` is required when `enableGooglePay` is true for a SetupIntent.
 
@@ -70,9 +70,9 @@ if (result.paymentResult === PaymentSheetEventsEnum.Completed) {
 
 Treat `Canceled` as the customer dismissing the sheet. Treat `Failed` as an error. Neither result authorizes fulfillment by itself.
 
-!::presentPaymentSheet::
+<!-- !::presentPaymentSheet:: -->
 
-!::PaymentSheetResultInterface::
+<!-- !::PaymentSheetResultInterface:: -->
 
 ## 3. addListener
 
@@ -92,7 +92,7 @@ await Promise.all([
 ]);
 ```
 
-!::PaymentSheetEventsEnum::
+<!-- !::PaymentSheetEventsEnum:: -->
 
 ## Reference
 

--- a/packages/payment/docs/payment-sheet.md
+++ b/packages/payment/docs/payment-sheet.md
@@ -1,0 +1,100 @@
+---
+title: "PaymentSheet"
+code: ["/docs/stripe/payment-sheet/payment-sheet.ts.md"]
+scrollActiveLine: [
+  {id: "", activeLine: {}},
+  {id: "1.-createpaymentsheet", activeLine: {['payment-sheet.ts']: [9, 22]}},
+  {id: "2.-presentpaymentsheet", activeLine: {['payment-sheet.ts']: [22, 28]}},
+  {id: "3.-addlistener", activeLine: {['payment-sheet.ts']: [4, 8]}}
+]
+---
+
+PaymentSheet collects payment details and confirms the Intent in one presentation. If you need a pending card plus a later confirmation step, use [PaymentFlow](./payment-flow.md).
+
+[![Image from Gyazo](https://i.gyazo.com/4356878ec43a90178ec3d831d6b47b10.gif)](https://gyazo.com/4356878ec43a90178ec3d831d6b47b10)
+
+Use a [PaymentIntent](https://stripe.com/docs/payments/payment-intents) to charge now, or a [SetupIntent](https://stripe.com/docs/payments/save-and-reuse?platform=web) to save a method for later. Create those objects on your server. See [Server Integration](./server-integration.md).
+
+## Platform support
+
+| Platform | PaymentSheet |
+| --- | --- |
+| iOS | Native Stripe PaymentSheet |
+| Android | Native Stripe PaymentSheet |
+| Web | `stripe-pwa-elements` card modal |
+
+Web does not render the native PaymentSheet. On web, `createPaymentSheet` uses `paymentIntentClientSecret` and optional `withZipCode`; the current web implementation does not support SetupIntents. Native-only options such as `defaultBillingDetails`, `shippingDetails`, `billingDetailsCollectionConfiguration`, `enableApplePay`, `enableGooglePay`, `style`, and `returnURL` are ignored.
+
+## 1. createPaymentSheet
+
+Fetch client-safe secrets from your backend, then call `createPaymentSheet`. The plugin does not talk to Stripe's secret API. Use `HttpClient`, `fetch`, or any HTTP client.
+
+On iOS and Android, provide **either** `paymentIntentClientSecret` **or** `setupIntentClientSecret`. On web, provide `paymentIntentClientSecret`. `customerId` and `customerEphemeralKeySecret` are optional together. If you set `customerId`, you must also set `customerEphemeralKeySecret`. A PaymentIntent without a Customer is valid; see the demo `intent/without-customer` shape in [Server Integration](./server-integration.md).
+
+```ts
+import { firstValueFrom } from 'rxjs';
+import { PaymentSheetEventsEnum, Stripe } from '@capacitor-community/stripe';
+
+const { paymentIntent, ephemeralKey, customer } = await firstValueFrom(
+  this.http.post<{
+    paymentIntent: string;
+    ephemeralKey: string;
+    customer: string;
+  }>(environment.api + 'intent', {}),
+);
+
+await Stripe.createPaymentSheet({
+  paymentIntentClientSecret: paymentIntent,
+  customerId: customer,
+  customerEphemeralKeySecret: ephemeralKey,
+  merchantDisplayName: 'rdlabo',
+});
+```
+
+!::createPaymentSheet::
+
+!::CreatePaymentSheetOption::
+
+Optional native settings include `style` (`alwaysLight` or `alwaysDark`, iOS only), `enableApplePay` with `applePayMerchantId`, `enableGooglePay`, `returnURL` for 3D Secure on iOS, and billing collection options. `withZipCode` is web only. `currencyCode` is required when `enableGooglePay` is true for a SetupIntent.
+
+## 2. presentPaymentSheet
+
+Call `presentPaymentSheet` only after `createPaymentSheet` succeeds.
+
+```ts
+const result = await Stripe.presentPaymentSheet();
+if (result.paymentResult === PaymentSheetEventsEnum.Completed) {
+  // Update UI only. Confirm the Intent with a webhook before fulfilling.
+}
+```
+
+Treat `Canceled` as the customer dismissing the sheet. Treat `Failed` as an error. Neither result authorizes fulfillment by itself.
+
+!::presentPaymentSheet::
+
+!::PaymentSheetResultInterface::
+
+## 3. addListener
+
+Register result listeners once at application startup, before you present the sheet. Prefer events over the Promise after Android Activity recreation. See [Event Listeners](./learn/event-listeners.md).
+
+```ts
+await Promise.all([
+  Stripe.addListener(PaymentSheetEventsEnum.Completed, () => {
+    console.log('PaymentSheetEventsEnum.Completed');
+  }),
+  Stripe.addListener(PaymentSheetEventsEnum.Canceled, () => {
+    console.log('PaymentSheetEventsEnum.Canceled');
+  }),
+  Stripe.addListener(PaymentSheetEventsEnum.Failed, (error) => {
+    console.log('PaymentSheetEventsEnum.Failed', error);
+  }),
+]);
+```
+
+!::PaymentSheetEventsEnum::
+
+## Reference
+
+- [Accept a payment (iOS)](https://stripe.com/docs/payments/accept-a-payment?platform=ios)
+- [Accept a payment (Android)](https://stripe.com/docs/payments/accept-a-payment?platform=android)

--- a/packages/payment/docs/react.md
+++ b/packages/payment/docs/react.md
@@ -1,0 +1,60 @@
+---
+title: "React Quick start"
+code: []
+scrollActiveLine: []
+---
+
+Wrap the application with `CapacitorStripeProvider`. The provider calls `Stripe.initialize`, checks Apple Pay and Google Pay availability, and registers `stripe-pwa-elements` on web.
+
+```tsx:App.tsx
+import { CapacitorStripeProvider } from '@capacitor-community/stripe/react';
+
+const App: React.FC = () => (
+  <CapacitorStripeProvider
+    publishableKey="Your Publishable Key"
+    fallback={<p>Loading...</p>}
+  >
+    <IonApp>{/* ... */}</IonApp>
+  </CapacitorStripeProvider>
+);
+
+export default App;
+```
+
+`CapacitorStripeProvider` also accepts optional `stripeAccount` for [Stripe Connect](https://stripe.com/docs/connect/authentication).
+
+## Use the Stripe client
+
+Read the initialized client with `useCapacitorStripe`. The returned `stripe` object is the same plugin instance as `Stripe` from `@capacitor-community/stripe`.
+
+```ts
+import { useCapacitorStripe } from '@capacitor-community/stripe/react';
+
+export const PaymentSheet: React.FC = () => {
+  const { stripe, isApplePayAvailable, isGooglePayAvailable } = useCapacitorStripe();
+  // ...
+};
+```
+
+```tsx
+export const PaymentSheet: React.FC = () => {
+  const { stripe } = useCapacitorStripe();
+  return (
+    <button
+      onClick={async () => {
+        await stripe.createPaymentSheet({
+          paymentIntentClientSecret,
+          merchantDisplayName: 'App Name',
+        });
+        await stripe.presentPaymentSheet();
+      }}
+    >
+      Pay
+    </button>
+  );
+};
+```
+
+Register result listeners once during application startup, not inside a payment button handler. See [Event Listeners](./learn/event-listeners.md).
+
+The official React demo is at [capacitor-community/stripe/demo/react](https://github.com/capacitor-community/stripe/tree/main/demo/react).

--- a/packages/payment/docs/server-integration.md
+++ b/packages/payment/docs/server-integration.md
@@ -1,0 +1,66 @@
+---
+title: "Server Integration"
+code: []
+scrollActiveLine: []
+---
+
+`@capacitor-community/stripe` only accepts client-safe values. Your backend creates PaymentIntents, SetupIntents, Customers, and ephemeral keys with the Stripe secret key. The plugin never calls the secret API.
+
+## Secret-key confinement
+
+Keep `sk_live_...` and `sk_test_...` on the server. Ship only the publishable key to the app, through `Stripe.initialize` or Android Google Pay metadata. Do not embed the secret key in Capacitor config, source control, or client logs.
+
+## Client secrets
+
+Create a [PaymentIntent](https://stripe.com/docs/payments/payment-intents) to charge now, or a [SetupIntent](https://stripe.com/docs/payments/save-and-reuse) to save a method for later. Return the Intent **client secret** to the app, not the secret key and not a raw charge.
+
+Customer ephemeral keys are optional. Use them with a Customer id when PaymentSheet or PaymentFlow should show saved methods. If you pass `customerId` to the plugin, you must also pass `customerEphemeralKeySecret`. A PaymentIntent without a Customer is valid.
+
+Map server fields to plugin options:
+
+| Server field | Plugin option |
+| --- | --- |
+| `paymentIntent` | `paymentIntentClientSecret` |
+| `setupIntent` | `setupIntentClientSecret` |
+| `ephemeralKey` | `customerEphemeralKeySecret` |
+| `customer` | `customerId` |
+
+## Response shapes
+
+PaymentIntent with a Customer:
+
+```json
+{
+  "paymentIntent": "pi_..._secret_...",
+  "ephemeralKey": "ek_...",
+  "customer": "cus_..."
+}
+```
+
+SetupIntent with a Customer:
+
+```json
+{
+  "setupIntent": "seti_..._secret_...",
+  "ephemeralKey": "ek_...",
+  "customer": "cus_..."
+}
+```
+
+PaymentIntent without a Customer:
+
+```json
+{
+  "paymentIntent": "pi_..._secret_..."
+}
+```
+
+Apple Pay uses a PaymentIntent client secret. Google Pay uses a PaymentIntent client secret on web; Android also accepts a SetupIntent client secret through the historically named `paymentIntentClientSecret` option. Native PaymentSheet and PaymentFlow accept either Intent secret, with or without Customer fields. The current web PaymentSheet accepts PaymentIntents only; web PaymentFlow accepts either Intent type.
+
+## Webhook authority
+
+`Completed` on the device is a UI signal. It is not proof that Stripe captured funds. Fulfill orders from verified [Stripe webhooks](https://docs.stripe.com/webhooks) such as `payment_intent.succeeded` or `setup_intent.succeeded`.
+
+Treat `Canceled` as the customer dismissing the sheet. Treat `Failed` and `FailedToLoad` as errors. Retry only after you create a new Intent when the previous one can no longer be confirmed.
+
+The official demo server that returns the shapes above is [capacitor-community/stripe/demo/server](https://github.com/capacitor-community/stripe/tree/main/demo/server).

--- a/packages/payment/docs/vanilla-js.md
+++ b/packages/payment/docs/vanilla-js.md
@@ -1,0 +1,26 @@
+---
+title: "Vanilla JS Quick start"
+code: []
+scrollActiveLine: []
+---
+
+Web uses `stripe-pwa-elements` custom elements. Install the peer dependency and register the elements once during bootstrap, before you present Stripe UI.
+
+```bash
+npm install stripe-pwa-elements
+```
+
+```ts
+import { defineCustomElements } from 'stripe-pwa-elements/loader';
+import { Stripe } from '@capacitor-community/stripe';
+
+defineCustomElements();
+
+await Stripe.initialize({
+  publishableKey: 'Your Publishable Key',
+});
+```
+
+`stripe-pwa-elements` is a Stencil library. If you need the loader details, see the [Stencil documentation](https://stenciljs.com/docs/overview).
+
+Web PaymentSheet and PaymentFlow render a card modal, not the native Stripe PaymentSheet. Apple Pay and Google Pay use the Payment Request Button and require HTTPS. Many native-only options such as `defaultBillingDetails`, `billingDetailsCollectionConfiguration`, `enableApplePay`, and `enableGooglePay` are ignored on web.

--- a/packages/payment/package.json
+++ b/packages/payment/package.json
@@ -27,7 +27,8 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapacitorCommunityStripe.podspec"
+    "CapacitorCommunityStripe.podspec",
+    "docs/"
   ],
   "author": "Masahiko Sakakibara <sakakibara@rdlabo.jp>",
   "license": "MIT",

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -2,7 +2,9 @@
 
 Stripe SDK bindings for Capacitor Applications.
 
+<!-- rdlabo-docs-omit -->
 **Documentation:** [Read the full documentation](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal)
+<!-- /rdlabo-docs-omit -->
 
 We have confirmed that it works well in the demo project. Refer to:
 
@@ -48,9 +50,11 @@ ext {
 If you are developing apps for Stripe Android devices (e.g. Stripe Reader S700), follow the Stripe's documentation for the client-side setup.
 - [Stripe - Android configure your app](https://docs.stripe.com/terminal/features/apps-on-devices/build?terminal-sdk-platform=android&lang-android=java#setup-app)
 
-
 ## Usage
 
+See [Configuration](./docs/configuration.md), [Collect a Payment](./docs/collect-a-payment.md), [Reader Lifecycle](./docs/reader-lifecycle.md), and [Tap to Pay](./docs/tap-to-pay.md).
+
+<!-- rdlabo-docs-omit -->
 ### Simple collect payment
 
 Register application-level Terminal event listeners once per JavaScript application startup, as early as possible during bootstrap—for example, from `main.ts`, an application initializer, or a singleton service initialized at startup—and before initializing or starting an operation. Keep them registered for the lifetime of their application-level owner:
@@ -1550,3 +1554,4 @@ Controls where the tap indicator appears on screen.
 | **`Processing`**      | <code>'PROCESSING'</code>        |
 
 </docgen-api>
+<!-- /rdlabo-docs-omit -->

--- a/packages/terminal/docs/collect-a-payment.md
+++ b/packages/terminal/docs/collect-a-payment.md
@@ -1,0 +1,147 @@
+---
+title: 'Collect a Payment'
+code: ['collect-a-payment/collect-payment.ts.md', 'collect-a-payment/connection-token.ts.md']
+scrollActiveLine:
+  [
+    { id: '', activeLine: { ['collect-payment.ts']: [1, 1] } },
+    { id: 'register-application-level-listeners', activeLine: { ['collect-payment.ts']: [6, 19] } },
+    { id: 'initialize', activeLine: { ['connection-token.ts']: [0, 34] } },
+    { id: 'supply-a-connection-token-securely', activeLine: { ['connection-token.ts']: [0, 34] } },
+    {
+      id: 'create-a-paymentintent-on-your-backend',
+      activeLine: { ['collect-payment.ts']: [34, 42] },
+    },
+    { id: 'discover-readers', activeLine: { ['collect-payment.ts']: [22, 30] } },
+    { id: 'connect-a-reader', activeLine: { ['collect-payment.ts']: [27, 34] } },
+    { id: 'collect-a-payment-method', activeLine: { ['collect-payment.ts']: [42, 44] } },
+    { id: 'confirm-the-payment-intent', activeLine: { ['collect-payment.ts']: [43, 45] } },
+    { id: 'handle-cancellation-and-errors', activeLine: { ['collect-payment.ts']: [14, 19] } },
+    { id: 'disconnect-the-reader', activeLine: { ['collect-payment.ts']: [44, 48] } },
+  ]
+---
+
+Collect an in-person payment with Stripe Terminal by registering listeners early, initializing the plugin, connecting a reader, and confirming a PaymentIntent.
+
+## Register application-level listeners
+
+Register Terminal event listeners once per JavaScript application startup, as early as possible during bootstrap—for example from `main.ts`, an application initializer, or a singleton service initialized at startup—and before initializing or starting an operation. Keep them registered for the lifetime of their application-level owner.
+
+!::TerminalEventsEnum::
+
+Typed `addListener` overloads cover most of these members. `DiscoveringReaders` and `CancelDiscoveredReaders` are emitted by native discovery start and cancel but do not have dedicated overloads; see the [API](./api.md) page.
+
+## Initialize
+
+Prefer an authenticated app-side request through `RequestedConnectionToken` and `setConnectionToken`. This lets your app attach its normal authorization credentials and validate failures. Register the listener before `initialize`; the Terminal SDK asks for a new, single-use connection token whenever it needs one. Set `isTest` while developing.
+
+!::initialize::
+
+### `tokenProviderEndpoint` compatibility mode
+
+`tokenProviderEndpoint` is available for simple deployments, but the v8.2.1 native clients send a bare HTTP **POST**: callers cannot add an authorization header or request body. Use it only when your server can authenticate and protect that request by other means. Never expose an unrestricted public token-creation endpoint.
+
+When `tokenProviderEndpoint` is set, the plugin sends an HTTP **POST** with an empty body. The response **must** be JSON with a `secret` string:
+
+```json
+{ "secret": "pst_..." }
+```
+
+That value is a Stripe Terminal [connection token](https://docs.stripe.com/terminal/fleet/connect-reader?terminal-sdk-platform=js#connection-token). Create it on the server with your **secret** API key (`stripe.terminal.connectionTokens.create()`). Never put the secret key, restricted keys that can create tokens, or raw connection tokens in the app binary, logs, or a public client config.
+
+The official demo exposes `POST /connection/token` and returns `{ secret }`; adapt its authentication and authorization to your application.
+
+:::message
+In v8.2.1, Android logs the `secret` returned through `tokenProviderEndpoint`, and web logs the options passed to `setConnectionToken`. Avoid endpoint mode on Android until the upstream logging is removed, avoid production web console retention, and update to a fixed plugin release when available.
+:::
+
+Web `initialize` requires a fresh plugin instance: calling it again after a successful init throws `Stripe Terminal has already been initialized`.
+
+## Supply a connection token securely
+
+Omit `tokenProviderEndpoint` and register `RequestedConnectionToken` **before** `initialize`. When the SDK needs a token, the plugin emits that event and waits for `setConnectionToken({ token })`.
+
+Fetch with your normal authorization mechanism, require a successful response, validate `secret`, and pass it as `token`. Call `setConnectionToken` only while a fetch is pending; Android and iOS reject extra calls with `Stripe Terminal do not pending fetchConnectionToken`. Never log the response or token.
+
+!::setConnectionToken::
+
+## Create a PaymentIntent on your backend
+
+Create the PaymentIntent on your server. The official demo uses `POST /connection/intent` and returns `{ paymentIntent }` as the **client secret**.
+
+Requirements that match the plugin and demo:
+
+- `payment_method_types` must include `card_present`
+- Keep the Stripe secret key on the server
+- Pass only the client secret into `collectPaymentMethod({ paymentIntent })`
+- Do not create or confirm card-present PaymentIntents with a publishable key in the app
+
+Example server shape from the demo:
+
+```ts
+await stripe.paymentIntents.create({
+  amount: 1000,
+  currency: 'usd',
+  payment_method_types: ['card_present'],
+  capture_method: 'automatic',
+});
+```
+
+## Discover readers
+
+Discover nearby or simulated readers. Provide a `TerminalConnectTypes` value and a Stripe Terminal `locationId` when the connection type needs it.
+
+`locationId` is used during Internet discovery and is required when connecting Tap to Pay, Bluetooth, and Android USB readers. Internet discovery can filter by location; Tap to Pay and Bluetooth pass the location into the connection configuration.
+
+Nuances:
+
+- **Web** supports `Internet` only. Any other `type` is unavailable.
+- **iOS Bluetooth** reports readers through `DiscoveredReaders` **multiple times** as the scan updates. See [Stripe: connect a Bluetooth reader (iOS)](https://docs.stripe.com/terminal/payments/connect-reader?terminal-sdk-platform=ios&reader-type=bluetooth). Set `bluetoothScanWaitTime` (milliseconds) so `discoverReaders` waits before resolving with the current list. `0` or omitted returns the first scan result.
+- **iOS** also emits `DiscoveringReaders` when the scan starts. USB, HandOff, and `Simulated` as a `type` are unimplemented.
+- **Android** requires `ACCESS_FINE_LOCATION` at runtime or `discoverReaders` rejects. `Simulated` is treated as Bluetooth discovery. `HandOff` is Apps on Devices.
+- Call `cancelDiscoverReaders` if the user leaves the scan UI. Web is a no-op for cancel. Always give the user a way to stop a long Bluetooth scan.
+
+Listen for `DiscoveredReaders` in addition to awaiting the promise. On iOS Bluetooth the listener is the live list; the promise may resolve earlier than the last event.
+
+!::discoverReaders::
+
+!::DiscoverReadersOptions::
+
+!::TerminalConnectTypes::
+
+## Connect a reader
+
+Connect to one of the discovered readers before collecting payment details. The `reader` object must come from the current discovery result (`serialNumber` is the plugin's primary identifier).
+
+`autoReconnectOnUnexpectedDisconnect` defaults to `false` and is applied for Tap to Pay and Bluetooth. Android USB currently enables auto-reconnect in the native connection config. Internet connections do not take this flag.
+
+`merchantDisplayName` and `onBehalfOf` apply to iOS Tap to Pay (`LocalMobileReader`). On Android, set connected-account and display values on the PaymentIntent instead.
+
+!::connectReader::
+
+## Collect a payment method
+
+Pass the PaymentIntent **client secret** from your backend to `collectPaymentMethod`. The plugin retrieves that PaymentIntent, then collects on the connected reader.
+
+!::collectPaymentMethod::
+
+## Confirm the payment intent
+
+Process and confirm the collected PaymentIntent. `confirmPaymentIntent` rejects if you have not successfully collected first (`PaymentIntent not found for confirmPaymentIntent`).
+
+!::confirmPaymentIntent::
+
+`ConfirmedPaymentIntent` is a client UI signal, not fulfillment authority. Fulfill the order only after your backend verifies a Stripe webhook such as `payment_intent.succeeded`.
+
+## Handle cancellation and errors
+
+- `cancelCollectPaymentMethod` cancels an in-flight collect. On success the promise resolves and `Canceled` is emitted.
+- `Failed` is emitted when `collectPaymentMethod` or `confirmPaymentIntent` fails. The same call's promise also rejects. The payload may include `message`, `code`, and `declineCode`.
+- Do not use `ConnectionStatusChange` to detect unexpected disconnects. Use `UnexpectedReaderDisconnect`, and for Bluetooth/USB also `DisconnectedReader`. See [Reader Lifecycle](./reader-lifecycle.md).
+
+!::cancelCollectPaymentMethod::
+
+## Disconnect the reader
+
+Disconnect when the payment flow is finished or the reader is no longer needed.
+
+!::disconnectReader::

--- a/packages/terminal/docs/collect-a-payment.md
+++ b/packages/terminal/docs/collect-a-payment.md
@@ -28,7 +28,7 @@ Register Terminal event listeners once per JavaScript application startup, as ea
 
 !::TerminalEventsEnum::
 
-Typed `addListener` overloads cover most of these members. `DiscoveringReaders` and `CancelDiscoveredReaders` are emitted by native discovery start and cancel but do not have dedicated overloads; see the [API](./api.md) page.
+Typed `addListener` overloads cover most of these members. `DiscoveringReaders` and `CancelDiscoveredReaders` are emitted by native discovery start and cancel but do not have dedicated overloads; see the [API](../README.md#api) page.
 
 ## Initialize
 

--- a/packages/terminal/docs/collect-a-payment.md
+++ b/packages/terminal/docs/collect-a-payment.md
@@ -26,7 +26,7 @@ Collect an in-person payment with Stripe Terminal by registering listeners early
 
 Register Terminal event listeners once per JavaScript application startup, as early as possible during bootstrap—for example from `main.ts`, an application initializer, or a singleton service initialized at startup—and before initializing or starting an operation. Keep them registered for the lifetime of their application-level owner.
 
-!::TerminalEventsEnum::
+<!-- !::TerminalEventsEnum:: -->
 
 Typed `addListener` overloads cover most of these members. `DiscoveringReaders` and `CancelDiscoveredReaders` are emitted by native discovery start and cancel but do not have dedicated overloads; see the [API](../README.md#api) page.
 
@@ -34,7 +34,7 @@ Typed `addListener` overloads cover most of these members. `DiscoveringReaders` 
 
 Prefer an authenticated app-side request through `RequestedConnectionToken` and `setConnectionToken`. This lets your app attach its normal authorization credentials and validate failures. Register the listener before `initialize`; the Terminal SDK asks for a new, single-use connection token whenever it needs one. Set `isTest` while developing.
 
-!::initialize::
+<!-- !::initialize:: -->
 
 ### `tokenProviderEndpoint` compatibility mode
 
@@ -62,7 +62,7 @@ Omit `tokenProviderEndpoint` and register `RequestedConnectionToken` **before** 
 
 Fetch with your normal authorization mechanism, require a successful response, validate `secret`, and pass it as `token`. Call `setConnectionToken` only while a fetch is pending; Android and iOS reject extra calls with `Stripe Terminal do not pending fetchConnectionToken`. Never log the response or token.
 
-!::setConnectionToken::
+<!-- !::setConnectionToken:: -->
 
 ## Create a PaymentIntent on your backend
 
@@ -102,11 +102,11 @@ Nuances:
 
 Listen for `DiscoveredReaders` in addition to awaiting the promise. On iOS Bluetooth the listener is the live list; the promise may resolve earlier than the last event.
 
-!::discoverReaders::
+<!-- !::discoverReaders:: -->
 
-!::DiscoverReadersOptions::
+<!-- !::DiscoverReadersOptions:: -->
 
-!::TerminalConnectTypes::
+<!-- !::TerminalConnectTypes:: -->
 
 ## Connect a reader
 
@@ -116,19 +116,19 @@ Connect to one of the discovered readers before collecting payment details. The 
 
 `merchantDisplayName` and `onBehalfOf` apply to iOS Tap to Pay (`LocalMobileReader`). On Android, set connected-account and display values on the PaymentIntent instead.
 
-!::connectReader::
+<!-- !::connectReader:: -->
 
 ## Collect a payment method
 
 Pass the PaymentIntent **client secret** from your backend to `collectPaymentMethod`. The plugin retrieves that PaymentIntent, then collects on the connected reader.
 
-!::collectPaymentMethod::
+<!-- !::collectPaymentMethod:: -->
 
 ## Confirm the payment intent
 
 Process and confirm the collected PaymentIntent. `confirmPaymentIntent` rejects if you have not successfully collected first (`PaymentIntent not found for confirmPaymentIntent`).
 
-!::confirmPaymentIntent::
+<!-- !::confirmPaymentIntent:: -->
 
 `ConfirmedPaymentIntent` is a client UI signal, not fulfillment authority. Fulfill the order only after your backend verifies a Stripe webhook such as `payment_intent.succeeded`.
 
@@ -138,10 +138,10 @@ Process and confirm the collected PaymentIntent. `confirmPaymentIntent` rejects 
 - `Failed` is emitted when `collectPaymentMethod` or `confirmPaymentIntent` fails. The same call's promise also rejects. The payload may include `message`, `code`, and `declineCode`.
 - Do not use `ConnectionStatusChange` to detect unexpected disconnects. Use `UnexpectedReaderDisconnect`, and for Bluetooth/USB also `DisconnectedReader`. See [Reader Lifecycle](./reader-lifecycle.md).
 
-!::cancelCollectPaymentMethod::
+<!-- !::cancelCollectPaymentMethod:: -->
 
 ## Disconnect the reader
 
 Disconnect when the payment flow is finished or the reader is no longer needed.
 
-!::disconnectReader::
+<!-- !::disconnectReader:: -->

--- a/packages/terminal/docs/configuration.md
+++ b/packages/terminal/docs/configuration.md
@@ -1,0 +1,98 @@
+---
+title: 'Configuration'
+code: []
+scrollActiveLine: []
+---
+
+Install Stripe Terminal and synchronize the native Capacitor projects.
+
+```bash
+npm install @capacitor-community/stripe-terminal
+npx cap sync
+```
+
+The plugin is `@capacitor-community/stripe-terminal` **v8.2.1**. Official demos:
+
+- [Tap to Pay / Internet / Bluetooth](https://github.com/capacitor-community/stripe/tree/main/demo/angular)
+- [Apps on Devices](https://github.com/capacitor-community/stripe/tree/main/demo/app-on-devices)
+
+| Requirement             | Minimum |
+| ----------------------- | ------- |
+| Capacitor               | 8       |
+| iOS                     | 15.0    |
+| Android `minSdkVersion` | 26      |
+
+## Platform and connection types
+
+`discoverReaders` takes a `TerminalConnectTypes` value. Support is not the same on every platform.
+
+| `TerminalConnectTypes` | Web                               | iOS                              | Android                        |
+| ---------------------- | --------------------------------- | -------------------------------- | ------------------------------ |
+| `Internet`             | Yes — **the only supported type** | Yes                              | Yes                            |
+| `Bluetooth`            | No                                | Yes                              | Yes                            |
+| `TapToPay`             | No                                | Yes                              | Yes                            |
+| `Usb`                  | No                                | Unimplemented                    | Yes                            |
+| `HandOff`              | No                                | Unimplemented                    | Yes (Apps on Devices)          |
+| `Simulated`            | No                                | Unimplemented as a discover type | Treated as Bluetooth discovery |
+
+On every platform, pass `isTest: true` to `initialize` when you want simulated readers for a **supported** connection type. Do not rely on `TerminalConnectTypes.Simulated` on iOS or web; use `Internet`, `Bluetooth`, or `TapToPay` with `isTest: true` instead.
+
+Web `discoverReaders` rejects with an unavailable error for any type other than `Internet`.
+
+### Platform-only APIs
+
+| API                          | Web                  | iOS                                 | Android                                               |
+| ---------------------------- | -------------------- | ----------------------------------- | ----------------------------------------------------- |
+| `setTapToPayUxConfiguration` | No-op (logs only)    | Unimplemented                       | Yes — call after `initialize`, before `connectReader` |
+| `isTapToPayAccountLinked`    | Unavailable (throws) | Yes — iOS 16.4+, after `initialize` | Unimplemented                                         |
+
+See [Tap to Pay](./tap-to-pay.md) for the setup sequence and limitations.
+
+### Web no-op and unsupported lifecycle methods
+
+These methods exist on the plugin interface but do not drive the Stripe Terminal JS SDK on web:
+
+- `cancelDiscoverReaders` — no-op
+- `setSimulatorConfiguration` — no-op
+- `installAvailableUpdate` — no-op
+- `cancelInstallUpdate` — no-op
+- `rebootReader` — no-op
+- `cancelReaderReconnection` — no-op
+- `setTapToPayUxConfiguration` — no-op
+
+`isTapToPayAccountLinked` throws `unavailable` on web.
+
+Internet readers on web still support `initialize`, `discoverReaders`, `connectReader`, `getConnectedReader`, `disconnectReader`, `collectPaymentMethod`, `cancelCollectPaymentMethod`, `confirmPaymentIntent`, `setReaderDisplay`, `clearReaderDisplay`, `setConnectionToken`, and the connection / payment status listeners.
+
+## Web configuration
+
+No additional steps are necessary. Only Internet readers are available.
+
+## iOS configuration
+
+No additional steps are necessary for the plugin. USB, HandOff, and `setTapToPayUxConfiguration` are unimplemented on iOS.
+
+## Android configuration
+
+Add permissions to your `android/app/src/main/AndroidManifest.xml` file:
+
+```diff
++ <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
++ <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
++ <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
++ <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
++ <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
++ <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+```
+
+`discoverReaders` rejects when `ACCESS_FINE_LOCATION` has not been granted at runtime.
+
+And update `minSdkVersion` to `26` in your `android/variables.gradle` file:
+
+```diff
+  ext {
+-    minSdkVersion = 24
++    minSdkVersion = 26
+```
+
+If you are developing apps for Stripe Android devices (for example Stripe Reader S700) and using `TerminalConnectTypes.HandOff`, follow [Stripe's client-side setup guide](https://docs.stripe.com/terminal/features/apps-on-devices/build?terminal-sdk-platform=android&lang-android=java#setup-app).

--- a/packages/terminal/docs/reader-lifecycle.md
+++ b/packages/terminal/docs/reader-lifecycle.md
@@ -1,0 +1,92 @@
+---
+title: 'Reader Lifecycle'
+code: ['reader-lifecycle/reader-lifecycle.ts.md']
+scrollActiveLine:
+  [
+    { id: '', activeLine: { ['reader-lifecycle.ts']: [1, 1] } },
+    { id: 'listen-for-software-updates', activeLine: { ['reader-lifecycle.ts']: [2, 35] } },
+    { id: 'listen-for-status-and-input', activeLine: { ['reader-lifecycle.ts']: [35, 63] } },
+    { id: 'set-reader-display', activeLine: { ['reader-lifecycle.ts']: [63, 78] } },
+    { id: 'cancel-discovery', activeLine: { ['reader-lifecycle.ts']: [78, 80] } },
+    { id: 'disconnect-and-reconnection', activeLine: { ['reader-lifecycle.ts']: [80, 112] } },
+    { id: 'error-handling', activeLine: { ['reader-lifecycle.ts']: [112, 119] } },
+  ]
+---
+
+Keep reader software updates, status, and display messaging under control so Terminal operations do not interrupt checkout.
+
+## Listen for software updates
+
+The reader may start updating itself when needed. Listen for available updates, install or cancel them, and surface progress while an install is running.
+
+Constraints:
+
+- Call `setSimulatorConfiguration` **before** `discoverReaders` when you need a simulated update (`SimulateReaderUpdate.UpdateAvailable` or `Required`). Web `setSimulatorConfiguration` is a no-op.
+- `StartInstallingUpdate`, `ReaderSoftwareUpdateProgress`, and `FinishInstallingUpdate` apply to Bluetooth and USB readers. A **mandatory** update on first connect installs automatically, **before** `ConnectedReader` and before `connectReader()` resolves. Sequence: `StartInstallingUpdate` → `ReaderSoftwareUpdateProgress` (repeated) → `FinishInstallingUpdate` → `ConnectedReader` → `connectReader()` resolves. Show UI so a long connect is not mistaken for a hang.
+- `ReportAvailableUpdate` means an optional update is ready; call `installAvailableUpdate` when the merchant can wait. Do not start an optional install during checkout.
+- `progress` is a float between `0` and `1`.
+- `cancelInstallUpdate` cancels an in-flight install when the SDK allows it. Web install/cancel methods are no-ops.
+- iOS Tap to Pay also reports install start/progress/finish through the Tap to Pay reader delegate. Android Tap to Pay UX is separate; see [Tap to Pay](./tap-to-pay.md).
+
+!::installAvailableUpdate::
+
+!::cancelInstallUpdate::
+
+!::setSimulatorConfiguration::
+
+## Listen for status and input
+
+For readers without a leader screen, retrieve battery level, reader events, display messages, and input prompts with listeners and show them on the mobile device.
+
+`BatteryLevel`, `ReaderEvent`, `RequestDisplayMessage`, and `RequestReaderInput` apply to Bluetooth and USB readers. Battery updates are emitted on connection and about every 10 minutes.
+
+## Set reader display
+
+On devices with a leader screen, show cart contents before `collectPaymentMethod`. Clear the display when you are done. Internet readers on web support these calls.
+
+!::setReaderDisplay::
+
+!::clearReaderDisplay::
+
+!::Cart::
+
+!::CartLineItem::
+
+## Cancel discovery
+
+Call `cancelDiscoverReaders` when the user leaves the scan screen or after a timeout. On success, native platforms emit `CancelDiscoveredReaders`. If nothing is in progress, the promise still resolves.
+
+iOS Bluetooth discovery can run for a long time and will keep emitting `DiscoveredReaders`. Pair cancel with `bluetoothScanWaitTime` or your own timeout. Web `cancelDiscoverReaders` is a no-op.
+
+!::cancelDiscoverReaders::
+
+## Disconnect and reconnection
+
+`disconnectReader` disconnects the current reader. If none is connected, the promise resolves.
+
+`DisconnectedReader` behavior:
+
+- Every reader type emits it in response to `disconnectReader()` **without** a `reason`.
+- Bluetooth and USB also emit it **with** a `reason` when the reader finishes disconnecting. A user-initiated disconnect therefore yields **two** events: acknowledgement, then the reasoned disconnect.
+
+Do **not** treat `ConnectionStatusChange` as an unexpected disconnect. Use `UnexpectedReaderDisconnect` to notify the user. You may call `discoverReaders` again to reconnect; always provide a timeout or `cancelDiscoverReaders`.
+
+Set `autoReconnectOnUnexpectedDisconnect: true` on `connectReader` for Tap to Pay and Bluetooth when you want the SDK to retry. Then listen for:
+
+- `ReaderReconnectStarted` — includes `reader` and `reason`
+- `ReaderReconnectSucceeded`
+- `ReaderReconnectFailed`
+
+`cancelReaderReconnection` cancels an in-flight reconnect. Web `rebootReader` and `cancelReaderReconnection` are no-ops.
+
+!::getConnectedReader::
+
+!::rebootReader::
+
+!::cancelReaderReconnection::
+
+## Error handling
+
+`Failed` fires when collect or confirm fails; the corresponding promise rejects with the same `message` / `code` / `declineCode` when the native SDK provides them.
+
+`UnexpectedReaderDisconnect` means the Terminal dropped the reader outside of `disconnectReader()`. For Bluetooth and USB, inspect `DisconnectedReader` for `DisconnectReason` (`POWERED_OFF`, `BLUETOOTH_DISABLED`, `CRITICALLY_LOW_BATTERY`, and others).

--- a/packages/terminal/docs/reader-lifecycle.md
+++ b/packages/terminal/docs/reader-lifecycle.md
@@ -28,11 +28,11 @@ Constraints:
 - `cancelInstallUpdate` cancels an in-flight install when the SDK allows it. Web install/cancel methods are no-ops.
 - iOS Tap to Pay also reports install start/progress/finish through the Tap to Pay reader delegate. Android Tap to Pay UX is separate; see [Tap to Pay](./tap-to-pay.md).
 
-!::installAvailableUpdate::
+<!-- !::installAvailableUpdate:: -->
 
-!::cancelInstallUpdate::
+<!-- !::cancelInstallUpdate:: -->
 
-!::setSimulatorConfiguration::
+<!-- !::setSimulatorConfiguration:: -->
 
 ## Listen for status and input
 
@@ -44,13 +44,13 @@ For readers without a leader screen, retrieve battery level, reader events, disp
 
 On devices with a leader screen, show cart contents before `collectPaymentMethod`. Clear the display when you are done. Internet readers on web support these calls.
 
-!::setReaderDisplay::
+<!-- !::setReaderDisplay:: -->
 
-!::clearReaderDisplay::
+<!-- !::clearReaderDisplay:: -->
 
-!::Cart::
+<!-- !::Cart:: -->
 
-!::CartLineItem::
+<!-- !::CartLineItem:: -->
 
 ## Cancel discovery
 
@@ -58,7 +58,7 @@ Call `cancelDiscoverReaders` when the user leaves the scan screen or after a tim
 
 iOS Bluetooth discovery can run for a long time and will keep emitting `DiscoveredReaders`. Pair cancel with `bluetoothScanWaitTime` or your own timeout. Web `cancelDiscoverReaders` is a no-op.
 
-!::cancelDiscoverReaders::
+<!-- !::cancelDiscoverReaders:: -->
 
 ## Disconnect and reconnection
 
@@ -79,11 +79,11 @@ Set `autoReconnectOnUnexpectedDisconnect: true` on `connectReader` for Tap to Pa
 
 `cancelReaderReconnection` cancels an in-flight reconnect. Web `rebootReader` and `cancelReaderReconnection` are no-ops.
 
-!::getConnectedReader::
+<!-- !::getConnectedReader:: -->
 
-!::rebootReader::
+<!-- !::rebootReader:: -->
 
-!::cancelReaderReconnection::
+<!-- !::cancelReaderReconnection:: -->
 
 ## Error handling
 

--- a/packages/terminal/docs/tap-to-pay.md
+++ b/packages/terminal/docs/tap-to-pay.md
@@ -1,0 +1,93 @@
+---
+title: 'Tap to Pay'
+code: ['tap-to-pay/tap-to-pay.ts.md']
+scrollActiveLine:
+  [
+    { id: '', activeLine: { ['tap-to-pay.ts']: [1, 1] } },
+    { id: 'platform-prerequisites', activeLine: { ['tap-to-pay.ts']: [1, 1] } },
+    { id: 'setup-sequence', activeLine: { ['tap-to-pay.ts']: [8, 11] } },
+    { id: 'account-link-check', activeLine: { ['tap-to-pay.ts']: [11, 16] } },
+    { id: 'ux-configuration', activeLine: { ['tap-to-pay.ts']: [16, 23] } },
+    { id: 'discover-and-connect', activeLine: { ['tap-to-pay.ts']: [23, 36] } },
+    { id: 'limitations', activeLine: { ['tap-to-pay.ts']: [1, 1] } },
+  ]
+---
+
+Tap to Pay collects contactless payments on a compatible phone or tablet without a separate card reader. Use `TerminalConnectTypes.TapToPay` after [configuration](./configuration.md) and a working [connection token](./collect-a-payment.md).
+
+The official demo exercises Tap to Pay, Internet, and Bluetooth in [demo/angular](https://github.com/capacitor-community/stripe/tree/main/demo/angular).
+
+## Platform prerequisites
+
+| Platform | Supported | Notes                                                                                                      |
+| -------- | --------- | ---------------------------------------------------------------------------------------------------------- |
+| Android  | Yes       | NFC-capable device, location permission, Stripe Tap to Pay on Android eligibility. `minSdkVersion` 26.     |
+| iOS      | Yes       | Tap to Pay on iPhone, iOS 16.4+ for the account-link check. `setTapToPayUxConfiguration` is unimplemented. |
+| Web      | No        | `discoverReaders({ type: TapToPay })` is unavailable.                                                      |
+
+Complete Stripe Dashboard Terminal setup and create a [Location](https://docs.stripe.com/terminal/fleet/locations). Pass that `locationId` into `discoverReaders`; the plugin uses it when connecting the Tap to Pay reader.
+
+Android `initialize` requests the location permission listed in [Configuration](./configuration.md). Bluetooth permissions are requested only when discovering `Bluetooth` or `Simulated` readers; Tap to Pay discovery itself does not request them.
+
+## Setup sequence
+
+1. Register application-level listeners.
+2. Register an authenticated connection-token provider with `RequestedConnectionToken` + `setConnectionToken`, then call `initialize`.
+3. On iOS, call `isTapToPayAccountLinked` (do not cache the result).
+4. On Android, optionally call `setTapToPayUxConfiguration`.
+5. `discoverReaders` with `type: TerminalConnectTypes.TapToPay` and `locationId`.
+6. `connectReader` with the discovered reader.
+7. Collect and confirm a `card_present` PaymentIntent as in [Collect a Payment](./collect-a-payment.md).
+
+!::initialize::
+
+## Account-link check
+
+`isTapToPayAccountLinked` is **iOS only** and requires iOS 16.4 or later. `initialize()` must have run so the SDK has a connection token provider. No reader connection is required and the call does not activate NFC.
+
+The answer is read from Apple on every call. Do not cache `isLinked`. For Stripe Connect, pass `onBehalfOf` as the connected account ID; omit it to check the account that owns the API key.
+
+Android and web reject the call (`unimplemented` / `unavailable`). Guard with a platform check or `.catch()` like the official demo does for Android-only UX configuration.
+
+!::isTapToPayAccountLinked::
+
+!::IsTapToPayAccountLinkedOptions::
+
+## UX configuration
+
+`setTapToPayUxConfiguration` is **Android only**. Call it after `initialize()` and before `connectReader()`. iOS returns unimplemented; web logs and returns.
+
+The installed Android implementation applies `colors` (`primary`, `success`, `error` as `'default'` or a hex string such as `'#FF5733'`) and `darkMode` (`SYSTEM`, `DARK`, `LIGHT`). The TypeScript `tapZone` field is declared but not applied on the current Android Terminal SDK used by v8.2.1.
+
+!::setTapToPayUxConfiguration::
+
+!::TapToPayUxConfiguration::
+
+!::TapToPayColorScheme::
+
+!::TapToPayColor::
+
+!::TapToPayTapZone::
+
+!::TapToPayDarkMode::
+
+## Discover and connect
+
+Discover with `TerminalConnectTypes.TapToPay` and a `locationId`. Simulated Tap to Pay uses `isTest: true` on `initialize`, not `TerminalConnectTypes.Simulated`.
+
+Connect the reader from the discovery result. `autoReconnectOnUnexpectedDisconnect` defaults to `false` and is supported for Tap to Pay. On iOS, `merchantDisplayName` and `onBehalfOf` are passed into the Tap to Pay connection configuration. On Android, set those values on the PaymentIntent instead.
+
+!::discoverReaders::
+
+!::connectReader::
+
+After connect, use `collectPaymentMethod` and `confirmPaymentIntent` with a server-created `card_present` PaymentIntent.
+
+## Limitations
+
+- Web cannot discover or connect Tap to Pay.
+- UX colors and dark mode are Android-only; iOS uses the system Tap to Pay on iPhone UI.
+- Account-link status is iOS-only and must be re-fetched from Apple each time.
+- `tapZone` is part of the TypeScript API but is not wired through on the installed Android SDK.
+- Optional reader software updates still follow [Reader Lifecycle](./reader-lifecycle.md) rules: do not install during checkout.
+- Keep Stripe secret keys and connection-token creation on the backend.

--- a/packages/terminal/docs/tap-to-pay.md
+++ b/packages/terminal/docs/tap-to-pay.md
@@ -39,7 +39,7 @@ Android `initialize` requests the location permission listed in [Configuration](
 6. `connectReader` with the discovered reader.
 7. Collect and confirm a `card_present` PaymentIntent as in [Collect a Payment](./collect-a-payment.md).
 
-!::initialize::
+<!-- !::initialize:: -->
 
 ## Account-link check
 
@@ -49,9 +49,9 @@ The answer is read from Apple on every call. Do not cache `isLinked`. For Stripe
 
 Android and web reject the call (`unimplemented` / `unavailable`). Guard with a platform check or `.catch()` like the official demo does for Android-only UX configuration.
 
-!::isTapToPayAccountLinked::
+<!-- !::isTapToPayAccountLinked:: -->
 
-!::IsTapToPayAccountLinkedOptions::
+<!-- !::IsTapToPayAccountLinkedOptions:: -->
 
 ## UX configuration
 
@@ -59,17 +59,17 @@ Android and web reject the call (`unimplemented` / `unavailable`). Guard with a 
 
 The installed Android implementation applies `colors` (`primary`, `success`, `error` as `'default'` or a hex string such as `'#FF5733'`) and `darkMode` (`SYSTEM`, `DARK`, `LIGHT`). The TypeScript `tapZone` field is declared but not applied on the current Android Terminal SDK used by v8.2.1.
 
-!::setTapToPayUxConfiguration::
+<!-- !::setTapToPayUxConfiguration:: -->
 
-!::TapToPayUxConfiguration::
+<!-- !::TapToPayUxConfiguration:: -->
 
-!::TapToPayColorScheme::
+<!-- !::TapToPayColorScheme:: -->
 
-!::TapToPayColor::
+<!-- !::TapToPayColor:: -->
 
-!::TapToPayTapZone::
+<!-- !::TapToPayTapZone:: -->
 
-!::TapToPayDarkMode::
+<!-- !::TapToPayDarkMode:: -->
 
 ## Discover and connect
 
@@ -77,9 +77,9 @@ Discover with `TerminalConnectTypes.TapToPay` and a `locationId`. Simulated Tap 
 
 Connect the reader from the discovery result. `autoReconnectOnUnexpectedDisconnect` defaults to `false` and is supported for Tap to Pay. On iOS, `merchantDisplayName` and `onBehalfOf` are passed into the Tap to Pay connection configuration. On Android, set those values on the PaymentIntent instead.
 
-!::discoverReaders::
+<!-- !::discoverReaders:: -->
 
-!::connectReader::
+<!-- !::connectReader:: -->
 
 After connect, use `collectPaymentMethod` and `confirmPaymentIntent` with a server-created `card_present` PaymentIntent.
 

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -16,7 +16,8 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapacitorCommunityStripeTerminal.podspec"
+    "CapacitorCommunityStripeTerminal.podspec",
+    "docs/"
   ],
   "author": "Masahiko Sakakibara",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Add `docs/` guides for payment, identity, and terminal that match the docs portal page list.
- Keep a short Usage section on each README and wrap the long examples plus docgen API in omit comments.
- Publish `docs/` from each package.

## Test plan
- [ ] Confirm `npm run docgen` still updates README `<docgen-index>` / `<docgen-api>` placeholders.
- [ ] Confirm GitHub still shows the omitted API reference.
- [ ] After publish, enable `englishFromPackage` for the three Stripe projects in rdlabo-docs.


Made with [Cursor](https://cursor.com)