### PR TITLE
docs: route legacy Identity page correctly

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,12 +15,15 @@
     <script>
       const legacyPath = location.pathname.replace(/^\/stripe\/?/, "/");
       const docsMatch = legacyPath.match(/^\/docs\/(.+?)\/?$/);
-      const target = docsMatch
-        ? "https://docs.rdlabo.dev/projects/capacitor-stripe/docs/" +
-          docsMatch[1]
-        : legacyPath === "/installation" || legacyPath === "/installation/"
-          ? "https://docs.rdlabo.dev/projects/capacitor-stripe/docs/configuration"
-          : "https://docs.rdlabo.dev/projects/capacitor-stripe";
+      const target =
+        legacyPath === "/docs/identity" || legacyPath === "/docs/identity/"
+          ? "https://docs.rdlabo.dev/projects/capacitor-stripe-identity/docs/identity-verification-sheet"
+          : docsMatch
+            ? "https://docs.rdlabo.dev/projects/capacitor-stripe/docs/" +
+              docsMatch[1]
+            : legacyPath === "/installation" || legacyPath === "/installation/"
+              ? "https://docs.rdlabo.dev/projects/capacitor-stripe/docs/configuration"
+              : "https://docs.rdlabo.dev/projects/capacitor-stripe";
       location.replace(target + location.search + location.hash);
     </script>
   </head>


### PR DESCRIPTION
Follow up the legacy Pages migration by handling /stripe/docs/identity before the generic /docs/* mapper. This keeps the historical Identity shortcut aligned with the centralized portal contract and sends it to the Stripe Identity verification sheet.