### PR TITLE
docs: link README guides to docs.rdlabo.dev

### DIFF
--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -32,7 +32,7 @@ see more details on Stripe's native Android SDK page [here](https://stripe.com/d
 
 ## Usage
 
-See [Configuration](./docs/configuration.md) and [Identity Verification Sheet](./docs/identity-verification-sheet.md).
+See [Configuration](https://docs.rdlabo.dev/projects/capacitor-stripe-identity/docs/configuration) and [Identity Verification Sheet](https://docs.rdlabo.dev/projects/capacitor-stripe-identity/docs/identity-verification-sheet).
 
 <!-- rdlabo-docs-omit -->
 If you want to implement, we recommend to read https://stripe.com/docs/identity .

--- a/packages/payment/README.md
+++ b/packages/payment/README.md
@@ -15,7 +15,7 @@ npx cap sync
 
 ## Usage
 
-See [Configuration](./docs/configuration.md) to install the plugin, then [PaymentSheet](./docs/payment-sheet.md), [PaymentFlow](./docs/payment-flow.md), [Apple Pay](./docs/apple-pay.md), and [Google Pay](./docs/google-pay.md).
+See [Configuration](https://docs.rdlabo.dev/projects/capacitor-stripe/docs/configuration) to install the plugin, then [PaymentSheet](https://docs.rdlabo.dev/projects/capacitor-stripe/docs/payment-sheet), [PaymentFlow](https://docs.rdlabo.dev/projects/capacitor-stripe/docs/payment-flow), [Apple Pay](https://docs.rdlabo.dev/projects/capacitor-stripe/docs/apple-pay), and [Google Pay](https://docs.rdlabo.dev/projects/capacitor-stripe/docs/google-pay).
 
 <!-- rdlabo-docs-omit -->
 ## How to use

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -52,7 +52,7 @@ If you are developing apps for Stripe Android devices (e.g. Stripe Reader S700),
 
 ## Usage
 
-See [Configuration](./docs/configuration.md), [Collect a Payment](./docs/collect-a-payment.md), [Reader Lifecycle](./docs/reader-lifecycle.md), and [Tap to Pay](./docs/tap-to-pay.md).
+See [Configuration](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal/docs/configuration), [Collect a Payment](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal/docs/collect-a-payment), [Reader Lifecycle](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal/docs/reader-lifecycle), and [Tap to Pay](https://docs.rdlabo.dev/projects/capacitor-stripe-terminal/docs/tap-to-pay).
 
 <!-- rdlabo-docs-omit -->
 ### Simple collect payment


### PR DESCRIPTION
## Summary

- point README guide links at their canonical pages on docs.rdlabo.dev
- remove repository-only guide links when no public documentation page exists

## Validation

- `git diff --check`
- verified linked pages against the docs.rdlabo.dev sitemap
- validated the updated README through the rdlabo-site extraction and link-normalization pipeline