### PR TITLE
docs: embed API references in guides

### DIFF
--- a/packages/payment/docs/learn/event-listeners.md
+++ b/packages/payment/docs/learn/event-listeners.md
@@ -1,5 +1,5 @@
 ---
-title: "Event Listeners"
+title: 'Event Listeners'
 code: []
 scrollActiveLine: []
 ---
@@ -22,8 +22,6 @@ await Promise.all([
 ]);
 ```
 
-<!-- !::addListener:: -->
-
 <!-- !::PluginListenerHandle:: -->
 
 ## Android activity recreation
@@ -37,6 +35,8 @@ If the original call still exists, behavior is unchanged: the Promise is settled
 Keep application-level result listeners registered for the lifetime of the JavaScript runtime. Do not add them in a button handler and remove them when a page unmounts if you still need the payment result after Android recreation.
 
 ## PaymentSheet events
+
+<!-- !::addListener.PaymentSheetEventsEnum:: -->
 
 <!-- !::PaymentSheetEventsEnum:: -->
 
@@ -52,6 +52,8 @@ Typical PaymentSheet flow:
 
 ## PaymentFlow events
 
+<!-- !::addListener.PaymentFlowEventsEnum:: -->
+
 <!-- !::PaymentFlowEventsEnum:: -->
 
 Typical PaymentFlow flow:
@@ -66,6 +68,8 @@ Typical PaymentFlow flow:
 
 ## Apple Pay events
 
+<!-- !::addListener.ApplePayEventsEnum:: -->
+
 <!-- !::ApplePayEventsEnum:: -->
 
 `DidSelectShippingContact` includes `contact` and `updateId`. On iOS, call `updateApplePaySheet` with that `updateId` and updated `paymentSummaryItems`. If JavaScript does not respond, the native sheet falls back to the original items after 25 seconds. `updateApplePaySheet` is not implemented on Android or web.
@@ -73,6 +77,8 @@ Typical PaymentFlow flow:
 `DidCreatePaymentMethod` includes the shipping `contact`. Apple does not return the full address until a successful payment.
 
 ## Google Pay events
+
+<!-- !::addListener.GooglePayEventsEnum:: -->
 
 <!-- !::GooglePayEventsEnum:: -->
 


### PR DESCRIPTION
## Summary

- Stripe event listener guideの手書きAPI誘導をdocgen placeholderへ置き換える
- docs.rdlabo.devで公開版docs.jsonから正確なシグネチャと型情報を展開できるようにする
- イベントリスナーはページに適した全体・イベント群・個別イベントの粒度を使う

## Validation

- Prettier check
- git diff --check
- rdlabo-siteの公開版docs.jsonに対して全placeholderが解決することを確認

## Dependency

Dotted event placeholders require rdlabo-dev/website#20 to be merged before this documentation is consumed by docs.rdlabo.dev.